### PR TITLE
Removing "exit 0" when skipping mark duplicates

### DIFF
--- a/templates/mark_duplicates.sh
+++ b/templates/mark_duplicates.sh
@@ -56,12 +56,17 @@ if [[ -z $(echo ${MD} | grep -i "yes") ]]; then
   echo "Skipping Mark Duplicates for ${RUN_TAG} (MD: ${MD}). Creating symbolic link to input - ${NO_MD_BAM}"
   ln -s ${INPUT_BAM} ${NO_MD_BAM}
   echo "${SKIP_FILE_KEYWORD}_MD" > ${STAT_NAME}
-  exit 0
+  # NOTE - DO NOT EXIT (e.g. "exit 0") Module mark_duplicates outputs ENV varialbes and to do this nextflow will append
+  # statements to write all environment variables to .command.env AT FILE END
+  #   e.g. echo SAMPLE_TAG=$SAMPLE_TAG > .command.env
+  # If you exit here, then .command.env will never be written
+else
+  echo "Running MarkDuplicates (MD: ${MD}): ${MD_TAG}. Writing to ${METRICS_DIR}"
+  CMD="!{PICARD} MarkDuplicates CREATE_INDEX=true METRICS_FILE=${METRICS_FILE} OUTPUT=${MD_BAM} INPUT=${INPUT_BAM}"
+  run_cmd $CMD
+
+  # TODO - make metrics file available as output for nextlow
+  cp ${METRICS_FILE} .
 fi
 
-echo "Running MarkDuplicates (MD: ${MD}): ${MD_TAG}. Writing to ${METRICS_DIR}"
-CMD="!{PICARD} MarkDuplicates CREATE_INDEX=true METRICS_FILE=${METRICS_FILE} OUTPUT=${MD_BAM} INPUT=${INPUT_BAM}"
-run_cmd $CMD
 
-# TODO - make metrics file available as output for nextlow
-cp ${METRICS_FILE} .


### PR DESCRIPTION
To export ENV variables, nextflow appends these statements to capture them AT THE END of the script. Because I exited early, these variables were never written
```
# capture process environment
set +u
echo SAMPLE_TAG=$SAMPLE_TAG > .command.env
```