### PR TITLE
Fixing regex to exclude date

### DIFF
--- a/templates/demultiplex.sh
+++ b/templates/demultiplex.sh
@@ -57,7 +57,7 @@ samplesheet_file=$(basename ${SAMPLESHEET})
 
 # SampleSheet_201204_PITT_0527_BHK752BBXY_i7.csv   ->   "PITT_0527_BHK752BBXY_i7"
 basename ${SAMPLESHEET}
-RUN_BASENAME=$(basename ${SAMPLESHEET} | grep -oP "(?<=_)[A-Za-z_0-9-]+")
+RUN_BASENAME=$(basename ${SAMPLESHEET} | grep -oP "(?<=[0-9]_)[A-Za-z_0-9-]+") # Capture after "[ANY NUM]_" (- ".csv")
 echo "RUN_BASENAME: ${RUN_BASENAME}"
 DEMUXED_DIR="!{FASTQ_DIR}/${RUN_BASENAME}"
 


### PR DESCRIPTION
**Description**: Excluding date at the beginning of the SampleSheet filename to create the FASTQ dir

BEFORE
```
SampleSheet_201204_PITT_0527_BHK752BBXY_i7.csv   ->   "201204_PITT_0527_BHK752BBXY_i7"
```

CHANGE
```
SampleSheet_201204_PITT_0527_BHK752BBXY_i7.csv   ->   "PITT_0527_BHK752BBXY_i7"
```
