### PR TITLE
Forcing emails to wait

### DIFF
--- a/modules/upload_stats.nf
+++ b/modules/upload_stats.nf
@@ -71,12 +71,12 @@ workflow upload_stats_wkflw {
     email(
         RUNNAME,
         IGO_EMAIL,
-        MD_METRICS_FILE_CH
-        AM_METRICS_FILE_CH
-        HS_METRICS_FILE_CH
-        OXOG_METRICS_FILE_CH
-        WGS_METRICS_FILE_CH
-        RNA_METRICS_FILE_CH
+        MD_METRICS_FILE_CH,
+        AM_METRICS_FILE_CH,
+        HS_METRICS_FILE_CH,
+        OXOG_METRICS_FILE_CH,
+        WGS_METRICS_FILE_CH,
+        RNA_METRICS_FILE_CH,
         GC_BIAS_METRICS_FILE_CH )
     out( task.out[0], "upload_stats" )
 


### PR DESCRIPTION
Adding the stat channels makes emailing wait until the preceding tasks complete