### PR TITLE
Demultiplex.sh Refactor

### DIFF
--- a/templates/demultiplex.sh
+++ b/templates/demultiplex.sh
@@ -79,6 +79,7 @@ DEMUXED_FASTQS=$(find ${DEMUXED_DIR} -type f -name "*.fastq.gz")
 
 if [[ "${DEMUX_ALL}" == "true" && ! -z $DEMUXED_FASTQS  ]]; then
   LOG="Skipping demux (DEMUX_ALL=${DEMUX_ALL}) of already demuxed directory: ${DEMUXED_DIR}"
+  echo "${LOG}"
   echo $LOG >> ${BCL_LOG}
 else
   chmod -R 775 $DEMUXED_DIR


### PR DESCRIPTION
Fixes issue where seqdataown has archived the run. Would previously fail w/ `--force true` because it would try to write the samplesheet to the run directory & change the permissions