### PR TITLE
Removing set -e (caused later grep to exit script)

### DIFF
--- a/templates/demultiplex.sh
+++ b/templates/demultiplex.sh
@@ -138,7 +138,6 @@ else
   eval ${JOB_CMD}
   UNDETERMINED_SIZE=$(du -sh  ${DEMUXED_DIR}/Undet*);
   PROJECT_SIZE=$(du -sh ${DEMUXED_DIR}/Proj*/*);
-  set -e
 
   cat ${BCL_LOG} >> ${DEMUX_LOG_FILE}
   cat ${BCL_LOG}


### PR DESCRIPTION
Because of `set -e`, the `is_dlp=$(echo ${SAMPLESHEET} | grep -E '_DLP.csv')` would fail later in the script, causing the pipeline to terminate.

```
$ help set
...
 -e  Exit immediately if a command exits with a non-zero status.
```

