### PR TITLE
E2E test of Main Pipeline (Cellranger)

### DIFF
--- a/.github/workflows/bin_tests.yml
+++ b/.github/workflows/bin_tests.yml
@@ -28,7 +28,8 @@ jobs:
         with:
           python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
-      # Runs a single command using the runners shell
+
+      # UNIT TESTS (Nothing that relies on docker - tests that can run in less than one minute)
       - name: Test demultiplex masks
         run: testPipeline/templates/demultiplex/demultiplex_test.sh
 
@@ -44,9 +45,19 @@ jobs:
       - name: Test cellranger outputs
         run: testPipeline/templates/cellranger/cellranger_test.sh
 
-      - name: samplesheet_stats_main_test HWG
+      # INTEGRATION TESTS - Put after building the docker image
+      - name: Build Docker nf-fastq-plus-playground
+        run: cd testPipeline && docker build -t nf-fastq-plus-playground .
+
+      - name: samplesheet_stats_main.nf HWG
         run: >
-          ./testPipeline/create_local_executor_config.sh nextflow.config &&
           cd testPipeline &&
-          docker build -t nf-fastq-plus-playground . > /dev/null &&
-          docker run -v /home/runner/work/nf-fastq-plus/nf-fastq-plus:/nf-fastq-plus nf-fastq-plus-playground
+          docker run --entrypoint /nf-fastq-plus/testPipeline/e2e/samplesheet_stats_main_test_hwg.sh -v $(pwd)/../../nf-fastq-plus:/nf-fastq-plus nf-fastq-plus-playground
+
+      # NOTE - DOCKER MEMORY (-m):
+      #   - cellranger will stall w/o enough. LOCAL_MEM=1 is fine as long as Docker has > 4GB memory
+      #   - CollectGcBiasMetrics will sometimes receive "java.lang.OutOfMemoryError: Java heap space" w/ -m=4g
+      - name: main.nf cellranger (demux & stats)
+        run: >
+          cd testPipeline &&
+          docker run -m=8g --entrypoint /nf-fastq-plus/testPipeline/e2e/cellranger_demux_stats.sh -v $(pwd)/../../nf-fastq-plus:/nf-fastq-plus nf-fastq-plus-playground

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ igo-pipeline.log
 pipeline_out
 work
 *.pyc
+testPipeline/e2e/main_test

--- a/main.nf
+++ b/main.nf
@@ -17,6 +17,7 @@ def process_bool(bool) {
 
 RUN=params.run
 DEMUX_ALL=process_bool(params.force)	// Whether to demux all runs, including w/ FASTQs already generated
+EXECUTOR=config.executor.name
 
 println """\
                   I G O   P I P E L I N E
@@ -52,6 +53,6 @@ workflow {
   split_sample_sheet_wkflw( detect_runs_wkflw.out.RUNPATH, COPIED_SAMPLE_SHEET_DIR, PROCESSED_SAMPLE_SHEET_DIR,
     LAB_SAMPLE_SHEET_DIR, SPLIT_SAMPLE_SHEETS )
   demultiplex_wkflw( split_sample_sheet_wkflw.out.SPLIT_SAMPLE_SHEETS, split_sample_sheet_wkflw.out.RUN_TO_DEMUX_DIR,
-    BCL2FASTQ, CELL_RANGER_ATAC, FASTQ_DIR, DEMUX_ALL, DATA_TEAM_EMAIL, CMD_FILE, DEMUX_LOG_FILE )
+    BCL2FASTQ, CELL_RANGER_ATAC, FASTQ_DIR, DEMUX_ALL, DATA_TEAM_EMAIL, CMD_FILE, DEMUX_LOG_FILE, EXECUTOR, LOCAL_MEM )
   samplesheet_stats_wkflw( demultiplex_wkflw.out.DEMUXED_DIR, demultiplex_wkflw.out.SAMPLESHEET, STATS_DIR, STATSDONEDIR )
 }

--- a/modules/demultiplex.nf
+++ b/modules/demultiplex.nf
@@ -17,6 +17,8 @@ process task {
     env DATA_TEAM_EMAIL
     env CMD_FILE
     env DEMUX_LOG_FILE
+    env EXECUTOR
+    env LOCAL_MEM
 
   output:
     stdout()
@@ -38,6 +40,8 @@ workflow demultiplex_wkflw {
     DATA_TEAM_EMAIL
     CMD_FILE
     DEMUX_LOG_FILE
+    EXECUTOR
+    LOCAL_MEM
 
   main:
     // splitText() will submit each line (a split sample sheet .csv) of @split_sample_sheets_path seperately
@@ -49,7 +53,7 @@ workflow demultiplex_wkflw {
       }
       .set{ split_ch }
     task( split_ch.SAMPLE_SHEET, RUN_TO_DEMUX_DIR, split_ch.RUNNAME, BCL2FASTQ, CELL_RANGER_ATAC, FASTQ_DIR, DEMUX_ALL,
-      DATA_TEAM_EMAIL, CMD_FILE, DEMUX_LOG_FILE )
+      DATA_TEAM_EMAIL, CMD_FILE, DEMUX_LOG_FILE, EXECUTOR, LOCAL_MEM )
     out( task.out[0], "demultiplex" )
 
   emit:

--- a/nextflow.config
+++ b/nextflow.config
@@ -66,4 +66,5 @@ env {
   CROSSCHECK_DIR="/home/igo/nextflow/crosscheck_metrics"
   DATA_TEAM_EMAIL="mcmanamd@mskcc.org naborsd@mskcc.org streidd@mskcc.org"
   IGO_EMAIL="streidd@mskcc.org naborsd@mskcc.org mcmanamd@mskcc.org cobbsc@mskcc.org hubermak@mskcc.org vialea@mskcc.org"
+  LOCAL_MEM=1
 }

--- a/templates/cellranger.sh
+++ b/templates/cellranger.sh
@@ -38,14 +38,19 @@ PROJECT_TAG=$(parse_param ${RUN_PARAMS_FILE} SAMPLE_TAG)
 RUNNAME=$(parse_param ${RUN_PARAMS_FILE} RUNNAME)
 SPECIES=$(parse_param ${RUN_PARAMS_FILE} SPECIES)
 
-# Find All Sample Directories, e.g. /igo/work/FASTQ/SCOTT_0339_AH2VTWBGXJ_10X/Project_11926/Sample_ESC_IGO_11926_1
-SAMPLE_FASTQ_DIRS_ACROSS_RUNS=$(find ${FASTQ_DIR} -mindepth 3 -maxdepth 3 -type d -name "Sample_${SAMPLE_TAG}")
-CELLRANGER_FASTQ_INPUT=$(echo ${SAMPLE_FASTQ_DIRS_ACROSS_RUNS} | tr ' ' ',') # cellranger input: comma-delimited list
-
 is_10X=$(echo $RECIPE | grep "10X_Genomics_")
 if [[ -z ${is_10X} ]]; then
   echo "Non-10X Recipe: ${RECIPE}. Skipping"
 else
+  echo "Searching directory ${FASTQ_DIR} for Sample_${SAMPLE_TAG} directory"
+  # Find All Sample Directories, e.g. /igo/work/FASTQ/SCOTT_0339_AH2VTWBGXJ_10X/Project_11926/Sample_ESC_IGO_11926_1
+  SAMPLE_FASTQ_DIRS_ACROSS_RUNS=$(find ${FASTQ_DIR} -mindepth 3 -maxdepth 3 -type d -name "Sample_${SAMPLE_TAG}")
+  if [[ -z ${SAMPLE_FASTQ_DIRS_ACROSS_RUNS} ]]; then
+    echo "Unable to locate FASTQ DIRS"
+    exit 1
+  fi
+
+  CELLRANGER_FASTQ_INPUT=$(echo ${SAMPLE_FASTQ_DIRS_ACROSS_RUNS} | tr ' ' ',') # cellranger input: comma-delimited list
   CELLRANGER_DIR=${STATS_DIR}/${RUNNAME}/cellranger/${PROJECT_TAG}/${SAMPLE_TAG}       # Specific path to BAMs
   mkdir -p ${CELLRANGER_DIR}
   cd ${CELLRANGER_DIR}

--- a/testPipeline/Dockerfile
+++ b/testPipeline/Dockerfile
@@ -1,36 +1,73 @@
-# Image w/ bwa & picard binaries
-FROM broadinstitute/genomes-in-the-cloud:2.3.1-1512499786
+FROM centos:7
 
-# Add the script that can be run as an entrypoint
-COPY e2e/samplesheet_stats_main_test.sh /nf-fastq-plus/testPipeline/e2e/samplesheet_stats_main_test.sh
+# Add Genome reference (Important for this to be first so it can be downloaded w/ most space available)
+RUN mkdir -p /igo/work/genomes/H.sapiens/GRCh37 && cd /igo/work/genomes/H.sapiens/GRCh37 && \
+  curl https://cf.10xgenomics.com/supp/cell-dna/refdata-GRCh37-1.0.0.tar.gz > refdata-GRCh37-1.0.0.tar.gz && \
+  /bin/tar -xvf refdata-GRCh37-1.0.0.tar.gz refdata-GRCh37-1.0.0/fasta/ --exclude=genome.fa.flat --exclude=genome.fa.pac --strip-components 2 && \
+  cd /igo/work/genomes/H.sapiens/GRCh37 && \
+  FILES=$(find . -type f -name "genome.fa*") && \
+  for f in $FILES; do mv $f ${f/genome.fa/GRCh37.fasta}; done && \
+  /bin/tar -xvf refdata-GRCh37-1.0.0.tar.gz refdata-GRCh37-1.0.0/fasta/genome.fa.pac --strip-components 2 && \
+  rm refdata-GRCh37-1.0.0.tar.gz && \
+  mv genome.fa.pac GRCh37.fasta.pac
 
-# Test script uses mock data at testPipeline/data (not needed if mounting nf-fastq-plus when running container)
-COPY data .
+# Install utilities needed for bcl2fastq
+RUN yum -y install rpm cpio
 
-# Install nextflow
-RUN wget -qO- https://get.nextflow.io | bash
+# Install bcl2fastq to /usr/local/bin/ (Ref - https://github.com/litd/docker-cellranger/blob/master/Dockerfile)
+RUN cd / && \
+  curl http://regmedsrv1.wustl.edu/Public_SPACE/litd/Public_html/pkg/bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm > bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm && \
+  rpm2cpio bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm  | cpio -idmv && \
+  rm -rf bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm
 
-# Add all executables, most importantly nextflow, to the path
-ENV PATH=$PATH:/usr/gitc
+# cellranger & picard will go here
+RUN mkdir -p /usr/local/bioinformatics
+
+# Install cellranger binary to /usr/local/bioinformatics/cellranger-6.0.0/bin/cellranger
+RUN cd /usr/local/bioinformatics && \
+  curl http://regmedsrv1.wustl.edu/Public_SPACE/litd/Public_html/pkg/cellranger-6.0.0.tar.gz > cellranger-6.0.0.tar.gz && \
+  tar -xzvf cellranger-6.0.0.tar.gz && \
+  rm -f cellranger-6.0.0.tar.gz
+
+# Add cellranger binary to PATH
+RUN yum -y install java-1.8.0-openjdk-devel git
+ENV JAVA_HOME=/usr/lib/jvm/java-openjdk
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+# Picard's CollectGcBiasMetrics requires R ("R is not installed on this machine. It is required for creating the chart.")
+RUN yum -y install epel-release
+RUN yum -y install R
+
+# Install Picard
+RUN git clone https://github.com/broadinstitute/picard.git && \
+  cd picard && \
+  ./gradlew shadowJar && \
+  mv build/libs/picard.jar /usr/local/bioinformatics && \
+  rm -rf picard
+
+RUN curl http://springdale.princeton.edu/data/springdale/7/x86_64/os/RPM-GPG-KEY-springdale > /etc/pki/rpm-gpg/RPM-GPG-KEY-springdale
+
+# Installs YUM repo needed to install BWA (REF - https://springdale.math.ias.edu/wiki/YumRepositories7)
+RUN echo "[computational-core]" > /etc/yum.repos.d/springdale.computational.repo && \
+  echo "name=Springdale computational Base \$releasever - \$basearch" >> /etc/yum.repos.d/springdale.computational.repo && \
+  echo "#baseurl=file:///springdale/computational/\$releasever/\$basearch" >> /etc/yum.repos.d/springdale.computational.repo && \
+  echo "#mirrorlist=http://mirror.math.princeton.edu/pub/springdale/puias/computational/\$releasever/\$basearch/mirrorlist" >> /etc/yum.repos.d/springdale.computational.repo && \
+  echo "baseurl=http://springdale.princeton.edu/data/springdale/computational/\$releasever/\$basearch" >> /etc/yum.repos.d/springdale.computational.repo && \
+  echo "gpgcheck=1" >> /etc/yum.repos.d/springdale.computational.repo && \
+  echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-springdale" >> /etc/yum.repos.d/springdale.computational.repo
+
+# Installs to /usr/bin/bwa
+RUN yum -y install bwa
+
+# Install nextflow (Should be to directory in PATH)
+RUN cd /usr/local/bin && curl -s https://get.nextflow.io | bash
 
 # Get around not having "mail" command. This will just output to stdout
 RUN ln -s /bin/echo /bin/mail
 
-# Add Genome reference used by Human Whole Genome & IDT
-RUN wget https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/annotation/GRCh37_latest/refseq_identifiers/GRCh37_latest_genomic.fna.gz && \
-  gunzip GRCh37_latest_genomic.fna.gz && \
-  mkdir -p /igo/work/genomes/H.sapiens/GRCh37/ && \
-  mv GRCh37_latest_genomic.fna /igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta
-
-# Setup directories of nextflow.config
+# Setup remaining directories of nextflow.config
 RUN mkdir -p /home/igo/log/nf_fasltq_plus && \
   mkdir -p /home/igo/log/nf_fastq_plus && \
   mkdir -p /home/igo/log/nf_fastq_plus && \
   mkdir -p /igo/stats/DONE && \
-  mkdir -p /home/igo/nextflow/crosscheck_metrics && \
-  touch /home/igo/log/nf_fasltq_plus/nf_fastq_run.log && \
-  touch /home/igo/log/nf_fastq_plus/commands.log && \
-  touch /home/igo/log/nf_fastq_plus/bcl2fastq.log
-
-# Code file to execute when the docker container starts up (`entrypoint.sh`)
-ENTRYPOINT ["/nf-fastq-plus/testPipeline/e2e/samplesheet_stats_main_test.sh", "HWG"]
+  mkdir -p /home/igo/nextflow/crosscheck_metrics

--- a/testPipeline/e2e/cellranger_demux_stats.sh
+++ b/testPipeline/e2e/cellranger_demux_stats.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Sets up and runs full pipeline for BCL files downloaded from cellranger
+#   Reference - https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/mkfastq
+# RUN:
+#   $ IMAGE=nf-fastq-plus-playground
+#   $ docker image build -t ${IMAGE} .
+#   $ docker run -m=4g -it --entrypoint /bin/bash -v $(pwd)/../../nf-fastq-plus:/nf-fastq-plus
+#   [root@1080a8b84933 /]$ /nf-fastq-plus/testPipeline/e2e/cellranger_demux_stats.sh
+
+LOCATION=$(realpath $(dirname "$0"))
+RUN=200514_ROSALIND_0001_FLOWCELL
+TEST_OUTPUT=${LOCATION}/main_test
+
+FASTQ_DIR=${TEST_OUTPUT}/FASTQ
+STATS_DIR=${TEST_OUTPUT}/STATS_DIR
+SEQUENCER_DIR=${TEST_OUTPUT}/sequencers
+LAB_SAMPLE_SHEET_DIR=${TEST_OUTPUT}/LIMS_SampleSheets
+PROCESSED_SAMPLE_SHEET_DIR="${TEST_OUTPUT}/DividedSampleSheets"
+COPIED_SAMPLE_SHEET_DIR="${TEST_OUTPUT}/SampleSheetCopies"
+STATSDONEDIR="${STATS_DIR}/DONE"
+
+mkdir -p ${FASTQ_DIR}
+mkdir -p ${STATS_DIR}
+mkdir -p ${SEQUENCER_DIR}
+mkdir -p ${LAB_SAMPLE_SHEET_DIR}
+mkdir -p ${PROCESSED_SAMPLE_SHEET_DIR}
+mkdir -p ${COPIED_SAMPLE_SHEET_DIR}
+mkdir -p ${STATSDONEDIR}
+
+LOG_DIR=${TEST_OUTPUT}/logs
+mkdir -p ${LOG_DIR}
+LOG_FILE="${LOG_DIR}/nf_fastq_run.log"
+CMD_FILE="${LOG_DIR}/commands.log"
+DEMUX_LOG_FILE="${LOG_DIR}/bcl2fastq.log"
+
+TEST_NEXTFLOW_CONFIG=${LOCATION}/nextflow.config
+
+# Create a basic samplesheet
+SAMPLE_SHEET=${LAB_SAMPLE_SHEET_DIR}/SampleSheet_${RUN}.csv
+echo "[Header],,,,,,,," > ${SAMPLE_SHEET}
+echo "IEMFileVersion,4,,,,,,," >> ${SAMPLE_SHEET}
+echo "Date,5/10/2021,,,,,,," >> ${SAMPLE_SHEET}
+echo "Workflow,GenerateFASTQ,,,,,,," >> ${SAMPLE_SHEET}
+echo "Application,MICHELLE,,,,,,," >> ${SAMPLE_SHEET}
+echo "Assay,,,,,,,," >> ${SAMPLE_SHEET}
+echo "Description,,,,,,,," >> ${SAMPLE_SHEET}
+echo "Chemistry,Default,,,,,,," >> ${SAMPLE_SHEET}
+echo ",,,,,,,," >> ${SAMPLE_SHEET}
+echo "[Reads],,,,,,,," >> ${SAMPLE_SHEET}
+echo "27,,,,,,,," >> ${SAMPLE_SHEET}
+echo "91,,,,,,,," >> ${SAMPLE_SHEET}
+echo ",,,,,,,," >> ${SAMPLE_SHEET}
+echo "[Settings],,,,,,,," >> ${SAMPLE_SHEET}
+echo "Adapter,,,,,,,," >> ${SAMPLE_SHEET}
+echo ",,,,,,,," >> ${SAMPLE_SHEET}
+echo "[Data],,,,,,,," >> ${SAMPLE_SHEET}
+echo "Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description" >> ${SAMPLE_SHEET}
+echo "1,Sample_10001_1,test_sample,Human,10X_Genomics_GeneExpression,SI-GA-A3,SI-GA-A3,Project_10001,Investigator_1" >> ${SAMPLE_SHEET}
+
+# Create nextflow config that 1) runs locally, 2) Has relative directory paths, 3) Has Docker images
+echo "executor {" > ${TEST_NEXTFLOW_CONFIG}
+echo "  name = 'local'" >> ${TEST_NEXTFLOW_CONFIG}
+echo "  scratch = true" >> ${TEST_NEXTFLOW_CONFIG}
+echo "  TMPDIR = '/scratch'" >> ${TEST_NEXTFLOW_CONFIG}
+echo "}" >> ${TEST_NEXTFLOW_CONFIG}
+cat ${LOCATION}/../../nextflow.config | sed -n '/env {/,$p' \
+  | sed -E "s#BWA=.*#BWA=\"/usr/bin/bwa\"#" \
+  | sed -E "s#PICARD=.*#PICARD=\"java -jar /usr/local/bioinformatics/picard.jar\"#" \
+  | sed -E "s#CELL_RANGER=.*#CELL_RANGER=\"/usr/local/bioinformatics/cellranger-6.0.0/bin/cellranger\"#" \
+  | sed -E "s#FASTQ_DIR=.*#FASTQ_DIR=\"${FASTQ_DIR}\"#" \
+  | sed -E "s#STATS_DIR=.*#STATS_DIR=\"${STATS_DIR}\"#" \
+  | sed -E "s#SEQUENCER_DIR=.*#SEQUENCER_DIR=\"${SEQUENCER_DIR}\"#" \
+  | sed -E "s#LAB_SAMPLE_SHEET_DIR=.*#LAB_SAMPLE_SHEET_DIR=\"${LAB_SAMPLE_SHEET_DIR}\"#" \
+  | sed -E "s#PROCESSED_SAMPLE_SHEET_DIR=.*#PROCESSED_SAMPLE_SHEET_DIR=\"${PROCESSED_SAMPLE_SHEET_DIR}\"#" \
+  | sed -E "s#COPIED_SAMPLE_SHEET_DIR=.*#COPIED_SAMPLE_SHEET_DIR=\"${COPIED_SAMPLE_SHEET_DIR}\"#" \
+  | sed -E "s#STATSDONEDIR=.*#STATSDONEDIR=\"${STATSDONEDIR}\"#" \
+  | sed -E "s#LOG_FILE=.*#LOG_FILE=\"${LOG_FILE}\"#" \
+  | sed -E "s#CMD_FILE=.*#CMD_FILE=\"${CMD_FILE}\"#" \
+  | sed -E "s#DEMUX_LOG_FILE=.*#DEMUX_LOG_FILE=\"${DEMUX_LOG_FILE}\"#" \
+  >> ${TEST_NEXTFLOW_CONFIG}
+  # | sed -E "s#=.*#=\"${}\"#" \
+
+# Download raw cellranger BCL files
+curl https://cf.10xgenomics.com/supp/cell-exp/cellranger-tiny-bcl-1.2.0.tar.gz -o cellranger-tiny-bcl-1.2.0.tar.gz 2> /dev/null
+
+# Unpack the files
+TEST_MACHINE_DIR=${SEQUENCER_DIR}/rosalind
+TEST_BCL_DIR=${TEST_MACHINE_DIR}/${RUN}
+mkdir -p ${TEST_MACHINE_DIR}
+tar -zxvf cellranger-tiny-bcl-1.2.0.tar.gz -C ${TEST_MACHINE_DIR} 2> /dev/null
+rm cellranger-tiny-bcl-1.2.0.tar.gz
+mv ${TEST_MACHINE_DIR}/cellranger-tiny-bcl-1.2.0 ${TEST_BCL_DIR}
+
+RUN_OUT=${RUN}.out
+# nextflow -C /nf-fastq-plus/testPipeline/e2e/nextflow.config run /nf-fastq-plus/testPipeline/e2e/../../main.nf --run 200514_ROSALIND_0001_FLOWCELL
+CMD="nextflow -C ${TEST_NEXTFLOW_CONFIG} run ${LOCATION}/../../main.nf --run ${RUN} > ${RUN_OUT}"
+echo $CMD
+eval $CMD
+
+tail -100 ${RUN_OUT}
+
+# VERIFICATIONS OF OUTPUT
+FILE_SUFFIXES=( ___MD.txt ___AM.txt ___gc_bias_metrics.txt )
+ERRORS=""
+echo "TEST 1: Checking for bam"
+FOUND_BAM=$(find ${STATS_DIR} -type f -name "*MD.bam")
+if [ -z ${FOUND_BAM} ]; then
+  ERROR="\tERROR: Pipeline didn't create MarkDuplicate BAM files\n"
+  ERRORS="${ERRORS}${ERROR}"
+  printf "$ERROR"
+else
+  printf "\tFound BAM: ${FOUND_BAM}\n"
+fi
+
+echo "TEST 2: Checking for following output stat files - ${FILE_SUFFIXES[@]}"
+for fs in "${FILE_SUFFIXES[@]}"; do
+  FOUND_FILES=$(find ${STATSDONEDIR} -type f -name "*${fs}")
+  if [ -z ${FOUND_FILES} ]; then
+    ERROR="\tERROR: Pipeline didn't create ${fs} files\n"
+    printf "$ERROR"
+    ERRORS="${ERRORS}${ERROR}"
+  else
+    printf "\tFound ${FOUND_FILES}\n"
+  fi
+done
+
+echo "TEST 3: Checking for cellranger stat output"
+CELLRANGER_OUTPUT=$(find ${STATS_DIR} -maxdepth 2 -type d -name cellranger)
+if [ -z ${CELLRANGER_OUTPUT} ]; then
+  ERROR="\tERROR: Pipeline didn't create cellranger output\n"
+  ERRORS="${ERRORS}${ERROR}"
+  printf "$ERROR"
+else
+  printf "\tFound CELLRANGER_OUTPUT=${CELLRANGER_OUTPUT}\n"
+  # Note - can't currently test for the cellranger output (e.g. web_summary.html & .cloupe files). The required
+  # reference files are at least 20-30 GB of space
+fi
+
+if [ -z "${ERRORS}" ]; then
+  echo "All tests successful - removing ${TEST_OUTPUT}"
+  rm -rf ${TEST_OUTPUT}
+else
+  cat ${OUT_FILE}
+  printf "ERRORS were found - \n${ERRORS}"
+  exit 1
+fi

--- a/testPipeline/e2e/samplesheet_stats_main_test_hwg.sh
+++ b/testPipeline/e2e/samplesheet_stats_main_test_hwg.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Sets up and runs stats pipeline for human whole genome (HWG)
+
+LOCATION=$(dirname "$0")
+
+ORIGINAL_CONFIG=${LOCATION}/../../nextflow.config
+if [[ -z ${ORIGINAL_CONFIG} || ! -f ${ORIGINAL_CONFIG} ]]; then
+  echo "Did not find original config"
+  exit 1
+fi
+
+# Writes a nextflow.config file that is the same as the sourced config except its executor is local
+TEMP_FILE="nextflow_temp.config"
+
+# Write the local executor
+echo "executor {" > ${TEMP_FILE}
+echo "  name = 'local'" >> ${TEMP_FILE}
+echo "  perJobMemLimit = true" >> ${TEMP_FILE}
+echo "  scratch = true" >> ${TEMP_FILE}
+echo "  TMPDIR = '/scratch'" >> ${TEMP_FILE}
+echo "}" >> ${TEMP_FILE}
+
+# Take whatever is in the original config for the environment variables. Replace bwa & picard w/ docker binaries
+cat ${ORIGINAL_CONFIG} | sed -n '/env {/,$p' \
+  | sed -E "s#BWA=.*#BWA=\"/usr/bin/bwa\"#" \
+  | sed -E "s#PICARD=.*#PICARD=\"java -jar /usr/local/bioinformatics/picard.jar\"#" \
+  >> ${TEMP_FILE}
+
+BACKUP=nextflow_original.config
+
+echo "Writing temporary nextflow.config file (Saving old to ${BACKUP})"
+cp ${ORIGINAL_CONFIG} ${BACKUP}
+mv ${TEMP_FILE} ${ORIGINAL_CONFIG}
+
+${LOCATION}/samplesheet_stats_main_test.sh HWG

--- a/testPipeline/templates/cellranger/cellranger_test.sh
+++ b/testPipeline/templates/cellranger/cellranger_test.sh
@@ -5,6 +5,10 @@ OUTPUT_FILE=output.txt
 LOCATION=$(dirname "$0")
 cd ${LOCATION}
 
+FASTQ_DIR=$(pwd)
+FASTQ_RUN_DIR=${FASTQ_DIR}/RUN
+FASTQ_SAMPLE_DIR=${FASTQ_RUN_DIR}/Project_10001/Sample_ESC_IGO_00001_1
+
 #########################################
 # Runs the cellranger command w/ test inputs
 # Globals:
@@ -27,9 +31,27 @@ run_cellranger() {
     STATS_DIR=$(pwd) ../../../templates/cellranger.sh > ${OUTPUT_FILE}
 }
 
+# Need to setup a mock FASTQ directory
+mkdir -p ${FASTQ_SAMPLE_DIR}
+touch ${FASTQ_SAMPLE_DIR}/Sample_ESC_IGO_00001_1_R1.fastq.gz
+touch ${FASTQ_SAMPLE_DIR}/Sample_ESC_IGO_00001_1_R2.fastq.gz
 
-run_cellranger GeneExpression
-EXPECTED_OUT="count --id=ESC_IGO_00001_1 --transcriptome=/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A --fastqs= --nopreflight --jobmode=lsf --mempercore=64 --disable-ui --maxjobs=200"
+TEST=GeneExpression
+run_cellranger ${TEST}
+EXPECTED_OUT="count --id=ESC_IGO_00001_1 --transcriptome=/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A --fastqs=.*/nf-fastq-plus/testPipeline/templates/cellranger/RUN/Project_10001/Sample_ESC_IGO_00001_1 --nopreflight --jobmode=lsf --mempercore=64 --disable-ui --maxjobs=200"
+ACTUAL_OUT=$(cat ${OUTPUT_FILE} | tr '\n' '   ')
+if [[ ! -z $(echo ${ACTUAL_OUT} | grep "${EXPECTED_OUT}") ]]; then
+  echo "Passed ${TEST}: ${EXPECTED_OUT}"
+  rm ${OUTPUT_FILE}
+  rm -rf ROSALIND_0339_AH2VTWBGXJ   # This is the FASTQ directory that we pointed the script to write to w/ FASTQ_DIR
+else
+  echo "Failed ${TEST}: ${ACTUAL_OUT}"
+  exit 1
+fi
+
+TEST=vdj
+run_cellranger ${TEST}
+EXPECTED_OUT="vdj --id=ESC_IGO_00001_1 --reference=/igo/work/nabors/genomes/10X_Genomics/VDJ/refdata-cellranger-vdj-GRCh38-alts-ensembl-2.0.0 --fastqs=.*/nf-fastq-plus/testPipeline/templates/cellranger/RUN/Project_10001/Sample_ESC_IGO_00001_1 --sample=ESC_IGO_00001_1 --nopreflight --jobmode=lsf --mempercore=64 --disable-ui --maxjobs=200"
 ACTUAL_OUT=$(cat ${OUTPUT_FILE})
 if [[ ! -z $(echo ${ACTUAL_OUT} | grep "${EXPECTED_OUT}") ]]; then
   echo "Passed ${TEST}: ${EXPECTED_OUT}"
@@ -40,8 +62,9 @@ else
   exit 1
 fi
 
-run_cellranger vdj
-EXPECTED_OUT="vdj --id=ESC_IGO_00001_1 --reference=/igo/work/nabors/genomes/10X_Genomics/VDJ/refdata-cellranger-vdj-GRCh38-alts-ensembl-2.0.0 --fastqs= --sample=ESC_IGO_00001_1 --nopreflight --jobmode=lsf --mempercore=64 --disable-ui --maxjobs=200"
+TEST=atac
+run_cellranger ${TEST}
+EXPECTED_OUT="count --id=ESC_IGO_00001_1 --fastqs=.*/nf-fastq-plus/testPipeline/templates/cellranger/RUN/Project_10001/Sample_ESC_IGO_00001_1 --reference=/igo/work/nabors/genomes/10X_Genomics/ATAC/refdata-cellranger-atac-GRCh38-1.0.1 --nopreflight --jobmode=lsf --mempercore=64 --disable-ui --maxjobs=200"
 ACTUAL_OUT=$(cat ${OUTPUT_FILE})
 if [[ ! -z $(echo ${ACTUAL_OUT} | grep "${EXPECTED_OUT}") ]]; then
   echo "Passed ${TEST}: ${EXPECTED_OUT}"
@@ -52,14 +75,5 @@ else
   exit 1
 fi
 
-run_cellranger atac
-EXPECTED_OUT="count --id=ESC_IGO_00001_1 --fastqs= --reference=/igo/work/nabors/genomes/10X_Genomics/ATAC/refdata-cellranger-atac-GRCh38-1.0.1 --nopreflight --jobmode=lsf --mempercore=64 --disable-ui --maxjobs=200"
-ACTUAL_OUT=$(cat ${OUTPUT_FILE})
-if [[ ! -z $(echo ${ACTUAL_OUT} | grep "${EXPECTED_OUT}") ]]; then
-  echo "Passed ${TEST}: ${EXPECTED_OUT}"
-  rm ${OUTPUT_FILE}
-  rm -rf ROSALIND_0339_AH2VTWBGXJ   # This is the FASTQ directory that we pointed the script to write to w/ FASTQ_DIR
-else
-  echo "Failed ${TEST}: ${ACTUAL_OUT}"
-  exit 1
-fi
+echo "All Tests Pass - Removing ${FASTQ_RUN_DIR}"
+rm -rf ${FASTQ_RUN_DIR}


### PR DESCRIPTION
**Description**: Uses the publicly available [cellranger BCL files](10x sample - https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/mkfastq) to run the `main.nf` nextflow pipeline, which runs the BCL-to-stat pipeline

### Features:
**Docker** (`Dockerfile`) - Recreated from `centos:7` base image, instead of `broadinstitute/genomes-in-the-cloud`, to be more lightweight
- Installs reference data (GRCh37 reference & BWA index) from 
- Installs needed RPM software packages for bioinformatics tools - `rpm`, `cpio`, `java-1.8.0-openjdk-devel`, `git`, `epel-release`, `R`
- Installs bioinformatics tools - `bcl2fastq`, `cellranger`, `nextflow`, `picard`, `bwa`
- Removed entrypoint to default to `/bin/bash`

**Tests** (_NOTE_: Test suite takes approximately 30-40 minutes to run (15-20 minutes is spent building the Docker container)
- `cellranger_demux_stats.sh` - downloads sample cellranger BCL files and uses them to run end-to-end tests
- `samplesheet_stats_main_test_hwg.sh` - wrapper for Human Whole Genome stats test (makes it cleaner to call from `bin_tests.yml`
- `cellranger_test.sh` - Updated to verify FASTQ files are found


**Pipeline**
- Passing `EXECUTOR` (`local` or `lsf`) so that tests can run in non-lsf Docker container