### PR TITLE
Adding create_run_bams_wkflw

### DIFF
--- a/modules/create_run_bams.nf
+++ b/modules/create_run_bams.nf
@@ -30,4 +30,5 @@ workflow create_run_bams_wkflw {
     OUTPUT_ID = mark_duplicates_wkflw.out.OUTPUT_ID
     PARAMS = mark_duplicates_wkflw.out.PARAMS
     METRICS_FILE = mark_duplicates_wkflw.out.METRICS_FILE
+    RUNNAME = generate_run_params_wkflw.out.RUNNAME
 }

--- a/modules/create_run_bams.nf
+++ b/modules/create_run_bams.nf
@@ -1,0 +1,33 @@
+/**
+ * Creates the sample BAMs for a specific run
+ */
+include { generate_run_params_wkflw } from './generate_run_params';
+include { create_sample_lane_jobs_wkflw } from './create_sample_lane_jobs';
+include { align_to_reference_wkflw } from './align_to_reference';
+include { merge_sams_wkflw } from './merge_sams';
+include { mark_duplicates_wkflw } from './mark_duplicates';
+
+workflow create_run_bams_wkflw {
+  take:
+    DEMUXED_DIR
+    SAMPLESHEET
+    STATS_DIR
+    STATSDONEDIR
+
+  main:
+    generate_run_params_wkflw( DEMUXED_DIR, SAMPLESHEET, RUN_PARAMS_FILE )
+    create_sample_lane_jobs_wkflw( generate_run_params_wkflw.out.SAMPLE_FILE_CH, RUN_PARAMS_FILE )
+    align_to_reference_wkflw( create_sample_lane_jobs_wkflw.out.LANE_PARAM_FILES, RUN_PARAMS_FILE, CMD_FILE,
+      BWA, PICARD, config.executor.name )
+    merge_sams_wkflw( align_to_reference_wkflw.out.PARAMS, align_to_reference_wkflw.out.SAM_CH, align_to_reference_wkflw.out.OUTPUT_ID,
+      RUN_PARAMS_FILE, CMD_FILE, PICARD, STATS_DIR )
+    // mark_duplicates_wkflw will output the input BAM if MD=no, otherwise it will output the MD BAM
+    mark_duplicates_wkflw( merge_sams_wkflw.out.PARAMS, merge_sams_wkflw.out.BAM_CH, merge_sams_wkflw.out.OUTPUT_ID,
+      RUN_PARAMS_FILE, CMD_FILE, PICARD, STATSDONEDIR, STATS_DIR )
+
+  emit:
+    BAM_CH = mark_duplicates_wkflw.out.BAM_CH
+    OUTPUT_ID = mark_duplicates_wkflw.out.SAMPLE_TAG
+    PARAMS = mark_duplicates_wkflw.out.PARAMS
+    METRICS_FILE = mark_duplicates_wkflw.out.METRICS_FILE
+}

--- a/modules/create_run_bams.nf
+++ b/modules/create_run_bams.nf
@@ -27,7 +27,7 @@ workflow create_run_bams_wkflw {
 
   emit:
     BAM_CH = mark_duplicates_wkflw.out.BAM_CH
-    OUTPUT_ID = mark_duplicates_wkflw.out.SAMPLE_TAG
+    OUTPUT_ID = mark_duplicates_wkflw.out.OUTPUT_ID
     PARAMS = mark_duplicates_wkflw.out.PARAMS
     METRICS_FILE = mark_duplicates_wkflw.out.METRICS_FILE
 }

--- a/modules/samplesheet_stats.nf
+++ b/modules/samplesheet_stats.nf
@@ -1,8 +1,4 @@
-include { generate_run_params_wkflw } from './generate_run_params';
-include { create_sample_lane_jobs_wkflw } from './create_sample_lane_jobs';
-include { align_to_reference_wkflw } from './align_to_reference';
-include { merge_sams_wkflw } from './merge_sams';
-include { mark_duplicates_wkflw } from './mark_duplicates';
+include { create_run_bams_wkflw } from './create_run_bams';
 include { alignment_summary_wkflw } from './collect_alignment_summary_metrics';
 include { collect_hs_metrics_wkflw } from './collect_hs_metrics';
 include { collect_oxoG_metrics_wkflw } from './collect_oxoG_metrics';
@@ -21,30 +17,22 @@ workflow samplesheet_stats_wkflw {
     STATSDONEDIR
 
   main:
-    generate_run_params_wkflw( DEMUXED_DIR, SAMPLESHEET, RUN_PARAMS_FILE )
-    create_sample_lane_jobs_wkflw( generate_run_params_wkflw.out.SAMPLE_FILE_CH, RUN_PARAMS_FILE )
-    align_to_reference_wkflw( create_sample_lane_jobs_wkflw.out.LANE_PARAM_FILES, RUN_PARAMS_FILE, CMD_FILE,
-      BWA, PICARD, config.executor.name )
-    merge_sams_wkflw( align_to_reference_wkflw.out.PARAMS, align_to_reference_wkflw.out.SAM_CH, align_to_reference_wkflw.out.OUTPUT_ID,
-      RUN_PARAMS_FILE, CMD_FILE, PICARD, STATS_DIR )
-    // mark_duplicates_wkflw will output the input BAM if MD=no, otherwise it will output the MD BAM
-    mark_duplicates_wkflw( merge_sams_wkflw.out.PARAMS, merge_sams_wkflw.out.BAM_CH, merge_sams_wkflw.out.OUTPUT_ID,
-        RUN_PARAMS_FILE, CMD_FILE, PICARD, STATSDONEDIR, STATS_DIR )
-    alignment_summary_wkflw( mark_duplicates_wkflw.out.PARAMS, mark_duplicates_wkflw.out.BAM_CH, mark_duplicates_wkflw.out.OUTPUT_ID,
+    create_run_bams_wkflw( DEMUXED_DIR, SAMPLESHEET, STATS_DIR, STATSDONEDIR )
+    alignment_summary_wkflw( create_run_bams_wkflw.out.PARAMS, create_run_bams_wkflw.out.BAM_CH, create_run_bams_wkflw.out.OUTPUT_ID,
         RUN_PARAMS_FILE, CMD_FILE, PICARD, STATSDONEDIR )
-    collect_hs_metrics_wkflw( mark_duplicates_wkflw.out.PARAMS, mark_duplicates_wkflw.out.BAM_CH, mark_duplicates_wkflw.out.OUTPUT_ID,
+    collect_hs_metrics_wkflw( create_run_bams_wkflw.out.PARAMS, create_run_bams_wkflw.out.BAM_CH, create_run_bams_wkflw.out.OUTPUT_ID,
         RUN_PARAMS_FILE, CMD_FILE, PICARD, STATSDONEDIR )
-    collect_oxoG_metrics_wkflw( mark_duplicates_wkflw.out.PARAMS, mark_duplicates_wkflw.out.BAM_CH, mark_duplicates_wkflw.out.OUTPUT_ID,
+    collect_oxoG_metrics_wkflw( create_run_bams_wkflw.out.PARAMS, create_run_bams_wkflw.out.BAM_CH, create_run_bams_wkflw.out.OUTPUT_ID,
         RUN_PARAMS_FILE, CMD_FILE, PICARD, STATSDONEDIR )
-    collect_wgs_metrics_wkflw( mark_duplicates_wkflw.out.PARAMS, mark_duplicates_wkflw.out.BAM_CH, mark_duplicates_wkflw.out.OUTPUT_ID,
+    collect_wgs_metrics_wkflw( create_run_bams_wkflw.out.PARAMS, create_run_bams_wkflw.out.BAM_CH, create_run_bams_wkflw.out.OUTPUT_ID,
         RUN_PARAMS_FILE, CMD_FILE, PICARD, STATSDONEDIR )
-    collect_rna_metrics_wkflw( mark_duplicates_wkflw.out.PARAMS, mark_duplicates_wkflw.out.BAM_CH, mark_duplicates_wkflw.out.OUTPUT_ID,
+    collect_rna_metrics_wkflw( create_run_bams_wkflw.out.PARAMS, create_run_bams_wkflw.out.BAM_CH, create_run_bams_wkflw.out.OUTPUT_ID,
         RUN_PARAMS_FILE, CMD_FILE, PICARD, STATSDONEDIR )
-    collect_gc_bias_wkflw( mark_duplicates_wkflw.out.PARAMS, mark_duplicates_wkflw.out.BAM_CH, mark_duplicates_wkflw.out.OUTPUT_ID,
+    collect_gc_bias_wkflw( create_run_bams_wkflw.out.PARAMS, create_run_bams_wkflw.out.BAM_CH, create_run_bams_wkflw.out.OUTPUT_ID,
         RUN_PARAMS_FILE, CMD_FILE, PICARD, STATSDONEDIR )
-    cellranger_wkflw( mark_duplicates_wkflw.out.PARAMS, mark_duplicates_wkflw.out.BAM_CH, mark_duplicates_wkflw.out.OUTPUT_ID,
+    cellranger_wkflw( create_run_bams_wkflw.out.PARAMS, create_run_bams_wkflw.out.BAM_CH, create_run_bams_wkflw.out.OUTPUT_ID,
         CELL_RANGER_ATAC, CELL_RANGER, CELL_RANGER_CNV, RUN_PARAMS_FILE, CMD_FILE, PICARD, STATSDONEDIR  )
-    upload_stats_wkflw( mark_duplicates_wkflw.out.METRICS_FILE.collect(), alignment_summary_wkflw.out.METRICS_FILE.collect(),
+    upload_stats_wkflw( create_run_bams_wkflw.out.METRICS_FILE.collect(), alignment_summary_wkflw.out.METRICS_FILE.collect(),
         collect_hs_metrics_wkflw.out.METRICS_FILE.collect(), collect_oxoG_metrics_wkflw.out.METRICS_FILE.collect(),
         collect_wgs_metrics_wkflw.out.METRICS_FILE.collect(), collect_rna_metrics_wkflw.out.METRICS_FILE.collect(),
         collect_gc_bias_wkflw.out.METRICS_FILE.collect(), generate_run_params_wkflw.out.RUNNAME, STATSDONEDIR,

--- a/modules/samplesheet_stats.nf
+++ b/modules/samplesheet_stats.nf
@@ -35,7 +35,7 @@ workflow samplesheet_stats_wkflw {
     upload_stats_wkflw( create_run_bams_wkflw.out.METRICS_FILE.collect(), alignment_summary_wkflw.out.METRICS_FILE.collect(),
         collect_hs_metrics_wkflw.out.METRICS_FILE.collect(), collect_oxoG_metrics_wkflw.out.METRICS_FILE.collect(),
         collect_wgs_metrics_wkflw.out.METRICS_FILE.collect(), collect_rna_metrics_wkflw.out.METRICS_FILE.collect(),
-        collect_gc_bias_wkflw.out.METRICS_FILE.collect(), generate_run_params_wkflw.out.RUNNAME, STATSDONEDIR,
+        collect_gc_bias_wkflw.out.METRICS_FILE.collect(), create_run_bams_wkflw.out.RUNNAME, STATSDONEDIR,
         IGO_EMAIL
     )
     fingerprint_wkflw( SAMPLESHEET, CROSSCHECK_DIR, upload_stats_wkflw.out.UPLOAD_DONE, CMD_FILE )


### PR DESCRIPTION
Modularizing how BAMs are created for a run. Includes: 
- generate_run_params_wkflw
- align_to_reference_wkflw
- merge_sams_wkflw
- mark_duplicates_wkflw