### PR TITLE
Updating References to GRC*38

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,13 +60,13 @@ jobs:
       - uses: actions/checkout@v2
       # docker run --entrypoint /nf-fastq-plus/testPipeline/e2e/samplesheet_stats_main_test_hwg.sh -v $(pwd)/../nf-fastq-plus:/nf-fastq-plus nf-fastq-plus-playground
       - name: stats
-        uses: mskcc/nf-fastq-plus@v2
+        uses: mskcc/nf-fastq-plus@v5
         with:
           entrypoint: testPipeline/e2e/samplesheet_stats_main_test_hwg.sh
           args: -v $(pwd)/../nf-fastq-plus:/nf-fastq-plus
       # docker run --entrypoint /nf-fastq-plus/testPipeline/e2e/cellranger_demux_stats.sh -v $(pwd)/../nf-fastq-plus:/nf-fastq-plus nf-fastq-plus-playground
       - name: main
-        uses: mskcc/nf-fastq-plus@v2
+        uses: mskcc/nf-fastq-plus@v5
         with:
           entrypoint: testPipeline/e2e/cellranger_demux_stats.sh
           args: -v $(pwd)/../nf-fastq-plus:/nf-fastq-plus

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM centos:7
 
 # Add Genome reference (Important for this to be first so it can be downloaded w/ most space available)
-RUN mkdir -p /igo/work/genomes/H.sapiens/GRCh37 && cd /igo/work/genomes/H.sapiens/GRCh37 && \
-  curl https://cf.10xgenomics.com/supp/cell-dna/refdata-GRCh37-1.0.0.tar.gz > refdata-GRCh37-1.0.0.tar.gz && \
-  /bin/tar -xvf refdata-GRCh37-1.0.0.tar.gz refdata-GRCh37-1.0.0/fasta/ --exclude=genome.fa.flat --exclude=genome.fa.pac --strip-components 2 && \
-  cd /igo/work/genomes/H.sapiens/GRCh37 && \
+RUN mkdir -p /igo/work/genomes/H.sapiens/GRCh38.p13 && cd /igo/work/genomes/H.sapiens/GRCh38.p13 && \
+  curl https://cf.10xgenomics.com/supp/cell-dna/refdata-GRCh38-1.0.0.tar.gz > refdata-GRCh38-1.0.0.tar.gz && \
+  /bin/tar -xvf refdata-GRCh38-1.0.0.tar.gz refdata-GRCh38-1.0.0/fasta/ --exclude=genome.fa.flat --exclude=genome.fa.pac --strip-components 2 && \
+  cd /igo/work/genomes/H.sapiens/GRCh38.p13 && \
   FILES=$(find . -type f -name "genome.fa*") && \
-  for f in $FILES; do mv $f ${f/genome.fa/GRCh37.fasta}; done && \
-  /bin/tar -xvf refdata-GRCh37-1.0.0.tar.gz refdata-GRCh37-1.0.0/fasta/genome.fa.pac --strip-components 2 && \
-  rm refdata-GRCh37-1.0.0.tar.gz && \
-  mv genome.fa.pac GRCh37.fasta.pac
+  for f in $FILES; do mv $f ${f/genome.fa/GRCh38.p13.dna.primary.assembly.fa}; done && \
+  /bin/tar -xvf refdata-GRCh38-1.0.0.tar.gz refdata-GRCh38-1.0.0/fasta/genome.fa.pac --strip-components 2 && \
+  rm refdata-GRCh38-1.0.0.tar.gz && \
+  mv genome.fa.pac GRCh38.p13.dna.primary.assembly.fa.pac
 
 # Install utilities needed for bcl2fastq
 RUN yum -y install rpm cpio

--- a/bin/generate_run_params.py
+++ b/bin/generate_run_params.py
@@ -60,10 +60,8 @@ def get_reference_configs(recipe, sample_type, species):
       For Example:
         {'GENOME': '/path/to/hg19.fa', 'REFERENCE': '/path/to/hg19/hg19.fa'}
     """
-    genome = None
-    if recipe in recipe_overrides:
-        genome = recipe_overrides[recipe]
-    else:
+    genome = find_mapping(recipe_overrides, recipe)
+    if genome == None:
         genome = find_mapping(species_genome_mapping, species)
 
     mapping = find_mapping(genome_reference_mapping, genome)

--- a/bin/run_param_config.py
+++ b/bin/run_param_config.py
@@ -77,7 +77,18 @@ recipe_overrides = {
     "M-IMPACT_v1": "mm10",
     "PCFDDR_.*": "hg19",
     "IWG.*": "hg19",
-    "CH_v1": "hg19"
+    "CH_v1": "hg19",
+    "Twist_Exome": "hg19",
+    "IDT_Exome_v1": "hg19",
+    "ADCC1_v2": "hg19",
+    "RDM": "hg19",
+    "myTYPE_V1": "hg19",
+    "PanCancerV2": "hg19",
+    "MissionBio-Heme": "hg19",
+    "WholeExome_v4": "hg19",
+    "AmpliSeq": "hg19",
+    "HemeBrainPACT_v1": "hg19"
+
 }
 """ Mapping of species to their genome-type """
 species_genome_mapping_UNORDERED = {

--- a/bin/run_param_config.py
+++ b/bin/run_param_config.py
@@ -74,7 +74,8 @@ recipe_overrides = {
     "CH_v1": "hg19",
     "MSK-ACCESS_v1":"GRCh38",
     "IMPACT505":"GRCh38",
-    "IDT_Exome_v2_FP_Viral_Probes":"GRCh38"
+    "IDT_Exome_v2_FP_Viral_Probes":"GRCh38",
+    "M-IMPACT_v1": "mm10"
 }
 """ Mapping of species to their genome-type """
 species_genome_mapping_UNORDERED = {

--- a/bin/run_param_config.py
+++ b/bin/run_param_config.py
@@ -71,11 +71,13 @@ recipe_type_mapping = get_ordered_dic(recipe_type_mapping_UNORDERED)
 """ Recipes that should have determine recipe (instead of species -> genome logic) """
 recipe_overrides = {
     "ADCC1_v3": "GRCh37",
-    "CH_v1": "hg19",
     "MSK-ACCESS_v1":"GRCh38",
     "IMPACT505":"GRCh38",
     "IDT_Exome_v2_FP_Viral_Probes":"GRCh38",
-    "M-IMPACT_v1": "mm10"
+    "M-IMPACT_v1": "mm10",
+    "PCFDDR_.*": "hg19",
+    "IWG.*": "hg19",
+    "CH_v1": "hg19"
 }
 """ Mapping of species to their genome-type """
 species_genome_mapping_UNORDERED = {
@@ -609,7 +611,7 @@ recipe_options_mapping_UNORDERED = {
         MSKQ: "no",
         MD: "yes"
     },
-    "PCFDDR_v1": {
+    "PCFDDR_.*": {
         BAITS: "/home/igo/resources/BED-Targets/PCFDDR_v1/PCFDDR_v1__BAITS.interval_list",
         TARGETS: "/home/igo/resources/BED-Targets/PCFDDR_v1/PCFDDR_v1__TARGETS.interval_list",
         MSKQ: "no",
@@ -705,8 +707,7 @@ recipe_options_mapping_UNORDERED = {
         MSKQ: "yes",
         MD: "yes"
     },
-     ".*IWG.*": {
-        # TODO - Delete "Twist_Exome" or change interval lists to be GRCh37
+     "IWG.*": {
         BAITS: "/home/igo/resources/BED-Targets/papaemme_IWG_OID43089_hg19_MHC_RNA_max10_20oct2015_BAITS.iList",
         TARGETS: "/home/igo/resources/BED-Targets/papaemme_IWG_OID43089_hg19_MHC_RNA_max10_20oct2015_TARGETS.iList",
         MSKQ: "no",

--- a/bin/run_param_config.py
+++ b/bin/run_param_config.py
@@ -78,9 +78,9 @@ recipe_overrides = {
 }
 """ Mapping of species to their genome-type """
 species_genome_mapping_UNORDERED = {
-    "Human": "GRCh37",
-    "Mouse": "mm10",
-    "Mouse_GeneticallyModified": "mm10",
+    "Human": "GRCh38",
+    "Mouse": "grcm38",
+    "Mouse_GeneticallyModified": "grcm38",
     "Drosophilia": "dm3",
     "Zebrafish": "danrer7",
     "Chicken": "galGal4",

--- a/bin/test/test_generate_run_params.py
+++ b/bin/test/test_generate_run_params.py
@@ -36,15 +36,15 @@ class TestSetupStats(unittest.TestCase):
 
     def test_get_reference_configs_human_dna(self):
         genome_configs_dna = get_reference_configs("", "DNA", "Human")
-        self.assertEqual(genome_configs_dna[GENOME], "/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta")
-        self.assertEqual(genome_configs_dna[REFERENCE], "/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta")
+        self.assertEqual(genome_configs_dna[GENOME], "/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa")
+        self.assertEqual(genome_configs_dna[REFERENCE], "/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa")
 
     def test_get_reference_configs_human_rna(self):
         genome_configs = get_reference_configs("", "RNA", "Human")
-        self.assertEqual(genome_configs[GENOME], '/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa')
-        self.assertEqual(genome_configs[REFERENCE], '/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa')
-        self.assertEqual(genome_configs[REF_FLAT], '/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/refFlat_ensembl.v75.txt')
-        self.assertEqual(genome_configs[RIBOSOMAL_INTERVALS], '/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/Homo_sapiens.GRCh37.75.rRNA.interval_list')
+        self.assertEqual(genome_configs[GENOME], '/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa')
+        self.assertEqual(genome_configs[REFERENCE], '/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa')
+        self.assertEqual(genome_configs[REF_FLAT], '/igo/work/nabors/bed_files/GRCh38_100_Ensembl/Homo_sapiens.GRCh38.100.ref.flat')
+        self.assertEqual(genome_configs[RIBOSOMAL_INTERVALS], '/igo/work/nabors/bed_files/GRCh38_100_Ensembl/SHORT__Homo_sapiens.GRCh38.100.rRNA.interval.list')
 
     def test_main_AmpliconSeq_Bacteria(self):
         argv = [ "-r", "AmpliconSeq", "-s", "Bacteria" ]
@@ -63,8 +63,8 @@ class TestSetupStats(unittest.TestCase):
         ref = parse_param(params, REFERENCE)
         typ = parse_param(params, TYPE)
         self.assertEqual(typ, "DNA")
-        self.assertEqual(genome, "/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa")
-        self.assertEqual(ref, "/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa")
+        self.assertEqual(genome, "/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa")
+        self.assertEqual(ref, "/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa")
 
     def test_main_AmpliconSeq_Plasmid(self):
         argv = [ "-r", "AmpliconSeq", "-s", "Plasmid" ]
@@ -102,69 +102,69 @@ class TestSetupStats(unittest.TestCase):
 
     def test_RNASeq(self):
         params = get_recipe_species_params("RNASeq", "Mouse")
-        expected_params = "GENOME=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa GTAG=GRCm38 MD=yes MSKQ=no REFERENCE=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa REF_FLAT=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.99.ref_flat RIBOSOMAL_INTERVALS=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.interval_list TYPE=RNA"
+        expected_params = "GENOME=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa GTAG=grcm38 MD=yes MSKQ=no REFERENCE=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa REF_FLAT=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.99.ref_flat RIBOSOMAL_INTERVALS=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.interval_list TYPE=RNA"
         self.verify_params(params, expected_params, "RNASeq", "Mouse")
 
     def test_RNASeq_Poly(self):
         params = get_recipe_species_params("RNASeq_PolyA", "Mouse")
-        expected_params = "GENOME=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa GTAG=GRCm38 MD=yes MSKQ=no REFERENCE=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa REF_FLAT=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.99.ref_flat RIBOSOMAL_INTERVALS=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.interval_list TYPE=RNA"
+        expected_params = "GENOME=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa GTAG=grcm38 MD=yes MSKQ=no REFERENCE=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa REF_FLAT=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.99.ref_flat RIBOSOMAL_INTERVALS=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.interval_list TYPE=RNA"
         self.verify_params(params, expected_params, "RNASeq_PolyA", "Mouse")
 
         params = get_recipe_species_params("RNASeq_PolyA", "Human")
-        expected_params = "GENOME=/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa GTAG=GRCh37 MD=yes MSKQ=no REFERENCE=/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa REF_FLAT=/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/refFlat_ensembl.v75.txt RIBOSOMAL_INTERVALS=/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/Homo_sapiens.GRCh37.75.rRNA.interval_list TYPE=RNA"
+        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa REF_FLAT=/igo/work/nabors/bed_files/GRCh38_100_Ensembl/Homo_sapiens.GRCh38.100.ref.flat RIBOSOMAL_INTERVALS=/igo/work/nabors/bed_files/GRCh38_100_Ensembl/SHORT__Homo_sapiens.GRCh38.100.rRNA.interval.list TYPE=RNA"
         self.verify_params(params, expected_params, "RNASeq_PolyA", "Human")
 
     def test_RNASeq_RiboDeplete(self):
         params = get_recipe_species_params("RNASeq_RiboDeplete", "Human")
-        expected_params = "GENOME=/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa GTAG=GRCh37 MD=yes MSKQ=no REFERENCE=/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa REF_FLAT=/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/refFlat_ensembl.v75.txt RIBOSOMAL_INTERVALS=/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/Homo_sapiens.GRCh37.75.rRNA.interval_list TYPE=RNA"
+        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa REF_FLAT=/igo/work/nabors/bed_files/GRCh38_100_Ensembl/Homo_sapiens.GRCh38.100.ref.flat RIBOSOMAL_INTERVALS=/igo/work/nabors/bed_files/GRCh38_100_Ensembl/SHORT__Homo_sapiens.GRCh38.100.rRNA.interval.list TYPE=RNA"
         self.verify_params(params, expected_params, "RNASeq_RiboDeplete", "Human")
 
     def test_SMARTerAmpSeq(self):
         params = get_recipe_species_params("SMARTerAmpSeq", "Mouse")
-        expected_params = "GENOME=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa GTAG=GRCm38 MD=yes MSKQ=no REFERENCE=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa REF_FLAT=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.99.ref_flat RIBOSOMAL_INTERVALS=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.interval_list TYPE=RNA"
+        expected_params = "GENOME=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa GTAG=grcm38 MD=yes MSKQ=no REFERENCE=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa REF_FLAT=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.99.ref_flat RIBOSOMAL_INTERVALS=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.interval_list TYPE=RNA"
         self.verify_params(params, expected_params, "SMARTerAmpSeq", "Mouse")
 
         params = get_recipe_species_params("SMARTerAmpSeq", "Human")
-        expected_params = "GENOME=/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa GTAG=GRCh37 MD=yes MSKQ=no REFERENCE=/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa REF_FLAT=/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/refFlat_ensembl.v75.txt RIBOSOMAL_INTERVALS=/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/Homo_sapiens.GRCh37.75.rRNA.interval_list TYPE=RNA"
+        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa REF_FLAT=/igo/work/nabors/bed_files/GRCh38_100_Ensembl/Homo_sapiens.GRCh38.100.ref.flat RIBOSOMAL_INTERVALS=/igo/work/nabors/bed_files/GRCh38_100_Ensembl/SHORT__Homo_sapiens.GRCh38.100.rRNA.interval.list TYPE=RNA"
         self.verify_params(params, expected_params, "SMARTerAmpSeq", "Human")
 
     def test_ATACSeq(self):
         # SEE 11107 of JAX_0461
         params = get_recipe_species_params("ATACSeq", "Human")
-        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GTAG=GRCh37 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta TYPE=DNA"
+        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa TYPE=DNA"
         self.verify_params(params, expected_params, "ATACSeq", "Human")
 
         params = get_recipe_species_params("ATACSeq", "Mouse")
-        expected_params = "GENOME=/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa GTAG=mm10 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa TYPE=DNA"
+        expected_params = "GENOME=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa GTAG=grcm38 MD=yes MSKQ=no REFERENCE=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa TYPE=DNA"
         self.verify_params(params, expected_params, "ATACSeq", "Mouse")
 
         params = get_recipe_species_params("ATACSeq", "Mouse_GeneticallyModified")
-        expected_params = "GENOME=/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa GTAG=mm10 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa TYPE=DNA"
+        expected_params = "GENOME=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa GTAG=grcm38 MD=yes MSKQ=no REFERENCE=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa TYPE=DNA"
         self.verify_params(params, expected_params, "ATACSeq", "Mouse_GeneticallyModified")
 
     def test_AmpliconSeq(self):
         # See 07798_T of PITT_0496
         params = get_recipe_species_params("AmpliconSeq", "Human")
-        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GTAG=GRCh37 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta TYPE=DNA"
+        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa TYPE=DNA"
         self.verify_params(params, expected_params, "AmpliconSeq", "Human")
 
         params = get_recipe_species_params("AmpliconSeq", "Mouse")
-        expected_params = "GENOME=/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa GTAG=mm10 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa TYPE=DNA"
+        expected_params = "GENOME=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa GTAG=grcm38 MD=yes MSKQ=no REFERENCE=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa TYPE=DNA"
         self.verify_params(params, expected_params, "AmpliconSeq", "Mouse")
 
     def test_ChIPSeq(self):
         # See 10123_H of JAX_0461
         params = get_recipe_species_params("ChIPSeq", "Human")
-        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GTAG=GRCh37 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta TYPE=DNA"
+        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa TYPE=DNA"
         self.verify_params(params, expected_params, "ChIPSeq", "Human")
 
         params = get_recipe_species_params("ChIPSeq", "Mouse")
-        expected_params = "GENOME=/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa GTAG=mm10 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa TYPE=DNA"
+        expected_params = "GENOME=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa GTAG=grcm38 MD=yes MSKQ=no REFERENCE=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa TYPE=DNA"
         self.verify_params(params, expected_params, "ChIPSeq", "Mouse")
 
     def test_IMPACT468(self):
         params = get_recipe_species_params("IMPACT468", "Human")
-        expected_params = "BAITS=/home/igo/resources/ilist/IMPACT468/b37/IMPACT468_BAITS.interval_list GENOME=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GTAG=GRCh37 MD=yes MSKQ=yes REFERENCE=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta TARGETS=/home/igo/resources/ilist/IMPACT468/b37/IMPACT468_TARGETS.interval_list TYPE=DNA"
+        expected_params = "BAITS=/home/igo/resources/ilist/IMPACT468/b37/IMPACT468_BAITS.interval_list GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MD=yes MSKQ=yes REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa TARGETS=/home/igo/resources/ilist/IMPACT468/b37/IMPACT468_TARGETS.interval_list TYPE=DNA"
         self.verify_params(params, expected_params, "IMPACT468", "Human")
 
     def test_IMPACT505(self):
@@ -174,7 +174,7 @@ class TestSetupStats(unittest.TestCase):
 
     def test_ShallowWGS(self):
         params = get_recipe_species_params("ShallowWGS", "Human")
-        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GTAG=GRCh37 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta TYPE=WGS"
+        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa TYPE=WGS"
         self.verify_params(params, expected_params, "ShallowWGS", "Human")
 
     def test_IDT_Exome(self):
@@ -184,30 +184,30 @@ class TestSetupStats(unittest.TestCase):
 
     def test_Agilent(self):
         params = get_recipe_species_params("Agilent_MouseAllExonV1", "Mouse")
-        expected_params = "BAITS=/home/igo/resources/BED-Targets/Agilent_MouseAllExonV1_mm10_v1_baits.ilist GTAG=mm10 GENOME=/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa MD=yes MSKQ=no REFERENCE=/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa TARGETS=/home/igo/resources/BED-Targets/Agilent_MouseAllExonV1_mm10_v1_targets.ilist TYPE=DNA"
+        expected_params = "BAITS=/home/igo/resources/BED-Targets/Agilent_MouseAllExonV1_mm10_v1_baits.ilist GTAG=grcm38 GENOME=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa MD=yes MSKQ=no REFERENCE=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa TARGETS=/home/igo/resources/BED-Targets/Agilent_MouseAllExonV1_mm10_v1_targets.ilist TYPE=DNA"
         self.verify_params(params, expected_params, "Agilent_MouseAllExonV1", "Mouse")
 
     def test_CRISPRSeq(self):
         params = get_recipe_species_params("CRISPRSeq", "Mouse")
-        expected_params = "GENOME=/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa GTAG=mm10 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa TYPE=DNA"
+        expected_params = "GENOME=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa GTAG=grcm38 MD=yes MSKQ=no REFERENCE=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa TYPE=DNA"
         self.verify_params(params, expected_params, "CRISPRSeq", "Mouse")
 
         params = get_recipe_species_params("CRISPRSeq", "Human")
-        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GTAG=GRCh37 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta TYPE=DNA"
+        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa TYPE=DNA"
         self.verify_params(params, expected_params, "CRISPRSeq", "Human")
 
     def test_CRISPRScreen(self):
         params = get_recipe_species_params("CRISPRScreen", "Human")
-        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GTAG=GRCh37 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta TYPE=DNA"
+        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa TYPE=DNA"
         self.verify_params(params, expected_params, "CRISPRScreen", "Human")
 
         params = get_recipe_species_params("CRISPRScreen", "Mouse")
-        expected_params = "GENOME=/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa GTAG=mm10 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa TYPE=DNA"
+        expected_params = "GENOME=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa GTAG=grcm38 MD=yes MSKQ=no REFERENCE=/igo/work/nabors/genomes/GRCm38/Mus_musculus.GRCm38.dna.primary_assembly.fa TYPE=DNA"
         self.verify_params(params, expected_params, "CRISPRScreen", "Mouse")
 
     def test_customCapture(self):
         params = get_recipe_species_params("CustomCapture", "Human")
-        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GTAG=GRCh37 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta TYPE=DNA"
+        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa TYPE=DNA"
         self.verify_params(params, expected_params, "CustomCapture", "Human")
 
     def test_MSK_ACCESS(self):
@@ -222,7 +222,7 @@ class TestSetupStats(unittest.TestCase):
 
     def test_HumanWholeGenome(self):
         params = get_recipe_species_params("HumanWholeGenome", "Human")
-        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GTAG=GRCh37 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta TYPE=WGS"
+        expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa TYPE=WGS"
         self.verify_params(params, expected_params, "HumanWholeGenome", "Human")
 
     def test_WholeGenomeSequencing_Bacteria(self):
@@ -232,7 +232,7 @@ class TestSetupStats(unittest.TestCase):
 
     def test_10xGeneExpression_Human(self):
         species = "Human"
-        expected_params = "CELLRANGER_COUNT=/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A CELLRANGER_ATAC=/igo/work/nabors/genomes/10X_Genomics/ATAC/refdata-cellranger-atac-GRCh38-1.0.1 CELLRANGER_VDJ=/igo/work/nabors/genomes/10X_Genomics/VDJ/refdata-cellranger-vdj-GRCh38-alts-ensembl-2.0.0 CELLRANGER_CNV=/igo/work/nabors/10X_Genomics_references/CNV/refdata-GRCh38-1.0.0 REFERENCE=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GENOME=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GTAG=GRCh37 MSKQ=no TYPE=DNA MD=yes"
+        expected_params = "CELLRANGER_COUNT=/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A CELLRANGER_ATAC=/igo/work/nabors/genomes/10X_Genomics/ATAC/refdata-cellranger-atac-GRCh38-1.0.1 CELLRANGER_VDJ=/igo/work/nabors/genomes/10X_Genomics/VDJ/refdata-cellranger-vdj-GRCh38-alts-ensembl-2.0.0 CELLRANGER_CNV=/igo/work/nabors/10X_Genomics_references/CNV/refdata-GRCh38-1.0.0 REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MSKQ=no TYPE=DNA MD=yes"
         geneExpression_recipes = [ "10X_Genomics_GeneExpression", "10X_Genomics_GeneExpression-3", "10X_Genomics_GeneExpression-5", "10X_Genomics_NextGEM-GeneExpression", "10X_Genomics_NextGEM-GeneExpression-5", "10X_Genomics_NextGEM_GeneExpression-5" ]
 
         for recipe in geneExpression_recipes:
@@ -241,7 +241,7 @@ class TestSetupStats(unittest.TestCase):
 
     def test_10xVDJ_Human(self):
         species = "Human"
-        expected_params = "CELLRANGER_COUNT=/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A CELLRANGER_ATAC=/igo/work/nabors/genomes/10X_Genomics/ATAC/refdata-cellranger-atac-GRCh38-1.0.1 CELLRANGER_VDJ=/igo/work/nabors/genomes/10X_Genomics/VDJ/refdata-cellranger-vdj-GRCh38-alts-ensembl-2.0.0 CELLRANGER_CNV=/igo/work/nabors/10X_Genomics_references/CNV/refdata-GRCh38-1.0.0 REFERENCE=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GENOME=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GTAG=GRCh37 MSKQ=no TYPE=DNA MD=yes"
+        expected_params = "CELLRANGER_COUNT=/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A CELLRANGER_ATAC=/igo/work/nabors/genomes/10X_Genomics/ATAC/refdata-cellranger-atac-GRCh38-1.0.1 CELLRANGER_VDJ=/igo/work/nabors/genomes/10X_Genomics/VDJ/refdata-cellranger-vdj-GRCh38-alts-ensembl-2.0.0 CELLRANGER_CNV=/igo/work/nabors/10X_Genomics_references/CNV/refdata-GRCh38-1.0.0 REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MSKQ=no TYPE=DNA MD=yes"
         geneExpression_recipes = [ "10X_Genomics_NextGem_VDJ", "10X_Genomics_NextGEM_VDJ", "10X_Genomics_NextGEM-VDJ", "10X_Genomics_VDJ", "10X_Genomics-VDJ" ]
 
         for recipe in geneExpression_recipes:
@@ -251,21 +251,21 @@ class TestSetupStats(unittest.TestCase):
     def test_10xVisium_Human(self):
         species = "Human"
         recipe = "10X_Genomics_Visium"
-        expected_params = "CELLRANGER_COUNT=/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A CELLRANGER_ATAC=/igo/work/nabors/genomes/10X_Genomics/ATAC/refdata-cellranger-atac-GRCh38-1.0.1 CELLRANGER_VDJ=/igo/work/nabors/genomes/10X_Genomics/VDJ/refdata-cellranger-vdj-GRCh38-alts-ensembl-2.0.0 CELLRANGER_CNV=/igo/work/nabors/10X_Genomics_references/CNV/refdata-GRCh38-1.0.0 REFERENCE=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GENOME=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GTAG=GRCh37 MSKQ=no TYPE=DNA MD=yes"
+        expected_params = "CELLRANGER_COUNT=/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A CELLRANGER_ATAC=/igo/work/nabors/genomes/10X_Genomics/ATAC/refdata-cellranger-atac-GRCh38-1.0.1 CELLRANGER_VDJ=/igo/work/nabors/genomes/10X_Genomics/VDJ/refdata-cellranger-vdj-GRCh38-alts-ensembl-2.0.0 CELLRANGER_CNV=/igo/work/nabors/10X_Genomics_references/CNV/refdata-GRCh38-1.0.0 REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MSKQ=no TYPE=DNA MD=yes"
         params = get_recipe_species_params(recipe, species)
         self.verify_params(params, expected_params, recipe, species)
 
     def test_10xATAC_Human(self):
         species = "Human"
         recipe = "10X_Genomics_ATAC"
-        expected_params = "CELLRANGER_COUNT=/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A CELLRANGER_ATAC=/igo/work/nabors/genomes/10X_Genomics/ATAC/refdata-cellranger-atac-GRCh38-1.0.1 CELLRANGER_VDJ=/igo/work/nabors/genomes/10X_Genomics/VDJ/refdata-cellranger-vdj-GRCh38-alts-ensembl-2.0.0 CELLRANGER_CNV=/igo/work/nabors/10X_Genomics_references/CNV/refdata-GRCh38-1.0.0 REFERENCE=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GENOME=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GTAG=GRCh37 MSKQ=no TYPE=DNA MD=yes"
+        expected_params = "CELLRANGER_COUNT=/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A CELLRANGER_ATAC=/igo/work/nabors/genomes/10X_Genomics/ATAC/refdata-cellranger-atac-GRCh38-1.0.1 CELLRANGER_VDJ=/igo/work/nabors/genomes/10X_Genomics/VDJ/refdata-cellranger-vdj-GRCh38-alts-ensembl-2.0.0 CELLRANGER_CNV=/igo/work/nabors/10X_Genomics_references/CNV/refdata-GRCh38-1.0.0 REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MSKQ=no TYPE=DNA MD=yes"
         params = get_recipe_species_params(recipe, species)
         self.verify_params(params, expected_params, recipe, species)
 
     def test_10xCNV_Human(self):
         species = "Human"
         recipe = "10X_Genomics_CNV"
-        expected_params = "CELLRANGER_COUNT=/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A CELLRANGER_ATAC=/igo/work/nabors/genomes/10X_Genomics/ATAC/refdata-cellranger-atac-GRCh38-1.0.1 CELLRANGER_VDJ=/igo/work/nabors/genomes/10X_Genomics/VDJ/refdata-cellranger-vdj-GRCh38-alts-ensembl-2.0.0 CELLRANGER_CNV=/igo/work/nabors/10X_Genomics_references/CNV/refdata-GRCh38-1.0.0 REFERENCE=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GENOME=/igo/work/genomes/H.sapiens/GRCh37/GRCh37.fasta GTAG=GRCh37 MSKQ=no TYPE=DNA MD=yes"
+        expected_params = "CELLRANGER_COUNT=/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A CELLRANGER_ATAC=/igo/work/nabors/genomes/10X_Genomics/ATAC/refdata-cellranger-atac-GRCh38-1.0.1 CELLRANGER_VDJ=/igo/work/nabors/genomes/10X_Genomics/VDJ/refdata-cellranger-vdj-GRCh38-alts-ensembl-2.0.0 CELLRANGER_CNV=/igo/work/nabors/10X_Genomics_references/CNV/refdata-GRCh38-1.0.0 REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MSKQ=no TYPE=DNA MD=yes"
         params = get_recipe_species_params(recipe, species)
         self.verify_params(params, expected_params, recipe, species)
 

--- a/bin/test/test_generate_run_params.py
+++ b/bin/test/test_generate_run_params.py
@@ -172,6 +172,11 @@ class TestSetupStats(unittest.TestCase):
         expected_params = "BAITS=/igo/home/igo/resources/ilist/GRCh38.p13/IMPACT505/IMPACT505_GRCh38_BAITS.intervalList GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MD=yes MSKQ=yes REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa TARGETS=/igo/home/igo/resources/ilist/GRCh38.p13/IMPACT505/IMPACT505_GRCh38_TARGETS.intervalList TYPE=DNA"
         self.verify_params(params, expected_params, "IMPACT505", "Human")
 
+    def test_M_IMPACT_v1(self):
+        params = get_recipe_species_params("M-IMPACT_v1", "Mouse")
+        expected_params = "REFERENCE=/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa TARGETS=/home/igo/resources/BED-Targets/IMPACT/MM_IMPACT/mm_IMPACT_v1_mm10_TARGETS.iList GENOME=/igo/work/genomes/M.musculus/mm10/BWA_0.7.5a/mouse_mm10__All.fa BAITS=/home/igo/resources/BED-Targets/IMPACT/MM_IMPACT/mm_IMPACT_v1_mm10_BAITS.iList GTAG=mm10 MSKQ=yes TYPE=DNA MD=yes"
+        self.verify_params(params, expected_params, "M-IMPACT_v1", "Mouse")
+
     def test_ShallowWGS(self):
         params = get_recipe_species_params("ShallowWGS", "Human")
         expected_params = "GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa GTAG=GRCh38 MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa TYPE=WGS"
@@ -181,6 +186,20 @@ class TestSetupStats(unittest.TestCase):
         params = get_recipe_species_params("IDT_Exome_v2_FP_Viral_Probes", "Human")
         expected_params = "BAITS=/igo/home/igo/resources/ilist/GRCh38.p13/IDT_Exome_v2/IDT_Exome_v2_GRCh38_BAITS.intervalList GTAG=GRCh38 GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa TARGETS=/igo/home/igo/resources/ilist/GRCh38.p13/IDT_Exome_v2/IDT_Exome_v2_GRCh38_TARGETS.intervalList TYPE=DNA"
         self.verify_params(params, expected_params, "IDT_Exome_v2_FP_Viral_Probes", "Human")
+
+    def test_IWG(self):
+        params = get_recipe_species_params("IWG_v2", "Human")
+        expected_params = "BAITS=/home/igo/resources/BED-Targets/papaemme_IWG_OID43089_hg19_MHC_RNA_max10_20oct2015_BAITS.iList GTAG=hg19 GENOME=/igo/work/genomes/H.sapiens/hg19/BWA_0.7.5a/human_hg19.fa MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/hg19/human_hg19.fa TARGETS=/home/igo/resources/BED-Targets/papaemme_IWG_OID43089_hg19_MHC_RNA_max10_20oct2015_TARGETS.iList TYPE=DNA"
+        self.verify_params(params, expected_params, "IWG_v2", "Human")
+
+    def test_PCFDDR(self):
+        # v1 & v2 should have same config
+        params = get_recipe_species_params("PCFDDR_v1", "Human")
+        expected_params = "BAITS=/home/igo/resources/BED-Targets/PCFDDR_v1/PCFDDR_v1__BAITS.interval_list GTAG=hg19 GENOME=/igo/work/genomes/H.sapiens/hg19/BWA_0.7.5a/human_hg19.fa MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/hg19/human_hg19.fa TARGETS=/home/igo/resources/BED-Targets/PCFDDR_v1/PCFDDR_v1__TARGETS.interval_list TYPE=DNA"
+        self.verify_params(params, expected_params, "PCFDDR_v1", "Human")
+        params = get_recipe_species_params("PCFDDR_v2", "Human")
+        expected_params = "BAITS=/home/igo/resources/BED-Targets/PCFDDR_v1/PCFDDR_v1__BAITS.interval_list GTAG=hg19 GENOME=/igo/work/genomes/H.sapiens/hg19/BWA_0.7.5a/human_hg19.fa MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/hg19/human_hg19.fa TARGETS=/home/igo/resources/BED-Targets/PCFDDR_v1/PCFDDR_v1__TARGETS.interval_list TYPE=DNA"
+        self.verify_params(params, expected_params, "PCFDDR_v2", "Human")
 
     def test_Agilent(self):
         params = get_recipe_species_params("Agilent_MouseAllExonV1", "Mouse")

--- a/bin/test/test_generate_run_params.py
+++ b/bin/test/test_generate_run_params.py
@@ -192,6 +192,13 @@ class TestSetupStats(unittest.TestCase):
         expected_params = "BAITS=/home/igo/resources/BED-Targets/papaemme_IWG_OID43089_hg19_MHC_RNA_max10_20oct2015_BAITS.iList GTAG=hg19 GENOME=/igo/work/genomes/H.sapiens/hg19/BWA_0.7.5a/human_hg19.fa MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/hg19/human_hg19.fa TARGETS=/home/igo/resources/BED-Targets/papaemme_IWG_OID43089_hg19_MHC_RNA_max10_20oct2015_TARGETS.iList TYPE=DNA"
         self.verify_params(params, expected_params, "IWG_v2", "Human")
 
+    def test_hg19_Overrides(self):
+        hg19_override_recipes = [ "PCFDDR_v1", "PCFDDR_v2", "IWG_v2", "Twist_Exome", "IDT_Exome_v1", "ADCC1_v2", "RDM", "myTYPE_V1", "PanCancerV2", "MissionBio-Heme", "WholeExome_v4", "AmpliSeq", "HemeBrainPACT_v1" ]
+        for recipe in hg19_override_recipes:
+            params = get_recipe_species_params(recipe, "Human")
+            expected_params = "GTAG=hg19 GENOME=/igo/work/genomes/H.sapiens/hg19/BWA_0.7.5a/human_hg19.fa REFERENCE=/igo/work/genomes/H.sapiens/hg19/human_hg19.fa"
+            self.verify_params(params, expected_params, recipe, "Human")
+
     def test_PCFDDR(self):
         # v1 & v2 should have same config
         params = get_recipe_species_params("PCFDDR_v1", "Human")

--- a/templates/collect_wgs_metrics.sh
+++ b/templates/collect_wgs_metrics.sh
@@ -47,7 +47,7 @@ METRICS_DIR=${STATSDONEDIR}/${MACHINE}  # Location of metrics & BAMs
 mkdir -p ${METRICS_DIR}
 STATS_FILENAME="${RUN_TAG}___WGS.txt"
 
-WGS_GENOMES="mm10\|wgs\|hg19\|grch37"
+WGS_GENOMES="mm10\|wgs\|hg19\|grch37\|grch38"
 if [ -z $(echo $GTAG | grep -i ${WGS_GENOMES}) ]; then
   MSG="Skipping CollectWgsMetrics for ${RUN_TAG}. GTAG (${GTAG}) not present in ${WGS_GENOMES} (TYPE: ${TYPE})";
   echo $MSG > ${STATS_FILENAME}


### PR DESCRIPTION
Removing GRCh37 & mm10 references from all pipeline runs, except for specific recipe overrides
**Majority of Recipes:**
* `GRCh37` -> `GRCh38`
* `mm10` -> `grcm38`

**hg19 Overrides:**
* `PCFDDR_v1`
* `PCFDDR_v2`
* `IWG_v2`
* `Twist_Exome`
* `IDT_Exome_v1`
* `ADCC1_v2`
* `RDM`
* `myTYPE_V1`
* `PanCancerV2`
* `MissionBio-Heme`
* `WholeExome_v4`
* `AmpliSeq`
* `HemeBrainPACT_v1`
