### PR TITLE
Adding HAPLOTYPE_MAP param. Only running fingerprinting if valid

### DIFF
--- a/bin/generate_run_params.py
+++ b/bin/generate_run_params.py
@@ -143,18 +143,18 @@ def main(argv):
     # Order is important because some assignments are dependent on previous assignments (see run_param_config.py)
     sample_type_dic = get_sample_type_from_recipe(recipe)
     sample_type = list(sample_type_dic.values())[0]     # { TYPE: "RNA" } -> "RNA"
-    refr = get_reference_configs(recipe, sample_type, species)
-    opts = get_recipe_options(recipe).copy()
+    refr = get_reference_configs(recipe, sample_type, species).copy()
+    opts = get_recipe_options(recipe)
     # TODO - Special Cases
     # "MethylCaptureSeq": sh $DIR/../PicardScripts/Methylseq.sh /igo/work/FASTQ/$RUNNAME/$PROJECT/
     # 10X_Genomics_*: sh $DIR/../PicardScripts/LaunchPipelines.sh $RUNTYPE --input /igo/work/FASTQ/$RUNNAME/$PROJECT/ --genome $GENOME --md $MARKDUPLICATES
     # DLP) echo "<<< DLP SAMPLES finished demuxing >>>"
 
     # Consolidate options
-    opts.update(refr)
-    opts.update(sample_type_dic)
+    refr.update(opts)
+    refr.update(sample_type_dic)
 
-    run_params = get_ordered_dic(opts) # Want to print in same order
+    run_params = get_ordered_dic(refr) # Want to print in same order
     output=""
     for k,v in run_params.items():
         output="{} {}".format(output, "{}={}".format(k, v))

--- a/bin/run_param_config.py
+++ b/bin/run_param_config.py
@@ -130,7 +130,7 @@ genome_reference_mapping_UNORDERED = {
             CELLRANGER_VDJ: "/igo/work/nabors/genomes/10X_Genomics/VDJ/refdata-cellranger-vdj-GRCh38-alts-ensembl-2.0.0",
             CELLRANGER_CNV: "/igo/work/nabors/10X_Genomics_references/CNV/refdata-GRCh38-1.0.0",
             CELLRANGER_COUNT: "/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A",
-            HAPLOTYPE_MAP: "/igo/home/igo/fingerprint_maps/map_files/hg38_ACCESS.map"
+            HAPLOTYPE_MAP: "/home/igo/fingerprint_maps/map_files/GRCh37_ACCESS.map"
         },
         "RNA": {
             GENOME: '/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa',

--- a/bin/run_param_config.py
+++ b/bin/run_param_config.py
@@ -79,9 +79,6 @@ recipe_type_mapping = get_ordered_dic(recipe_type_mapping_UNORDERED)
 """ Recipes that should have determine recipe (instead of species -> genome logic) """
 recipe_overrides = {
     "ADCC1_v3": "GRCh37",
-    "MSK-ACCESS_v1":"GRCh38",
-    "IMPACT505":"GRCh38",
-    "IDT_Exome_v2_FP_Viral_Probes":"GRCh38",
     "M-IMPACT_v1": "mm10",
     "PCFDDR_.*": "hg19",
     "IWG.*": "hg19",

--- a/bin/run_param_config.py
+++ b/bin/run_param_config.py
@@ -13,6 +13,7 @@ CELLRANGER_ATAC = "CELLRANGER_ATAC"
 CELLRANGER_VDJ = "CELLRANGER_VDJ"
 CELLRANGER_CNV = "CELLRANGER_CNV"
 CELLRANGER_COUNT = "CELLRANGER_COUNT"
+HAPLOTYPE_MAP = "HAPLOTYPE_MAP"
 
 # 3) Determined by recipe (see: recipe_options_mapping)
 BAITS="BAITS"
@@ -107,7 +108,8 @@ genome_reference_mapping_UNORDERED = {
     "hg19": {
         DEFAULT: {
             GENOME: "/igo/work/genomes/H.sapiens/hg19/BWA_0.7.5a/human_hg19.fa",
-            REFERENCE: "/igo/work/genomes/H.sapiens/hg19/human_hg19.fa"
+            REFERENCE: "/igo/work/genomes/H.sapiens/hg19/human_hg19.fa",
+            HAPLOTYPE_MAP: "/home/igo/fingerprint_maps/map_files/hg19_ACCESS.map"
         },
         "RNA": {
             REF_FLAT: "/home/igo/resources/BED-Targets/hg19-Ref_Flat.txt",
@@ -127,7 +129,8 @@ genome_reference_mapping_UNORDERED = {
             CELLRANGER_ATAC: "/igo/work/nabors/genomes/10X_Genomics/ATAC/refdata-cellranger-atac-GRCh38-1.0.1",
             CELLRANGER_VDJ: "/igo/work/nabors/genomes/10X_Genomics/VDJ/refdata-cellranger-vdj-GRCh38-alts-ensembl-2.0.0",
             CELLRANGER_CNV: "/igo/work/nabors/10X_Genomics_references/CNV/refdata-GRCh38-1.0.0",
-            CELLRANGER_COUNT: "/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A"
+            CELLRANGER_COUNT: "/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A",
+            HAPLOTYPE_MAP: "/igo/home/igo/fingerprint_maps/map_files/hg38_ACCESS.map"
         },
         "RNA": {
             GENOME: '/igo/work/nabors/bed_files/GRCh37_RNA_Ensembl/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa',
@@ -143,7 +146,8 @@ genome_reference_mapping_UNORDERED = {
             CELLRANGER_ATAC: "/igo/work/nabors/genomes/10X_Genomics/ATAC/refdata-cellranger-atac-GRCh38-1.0.1",
             CELLRANGER_VDJ: "/igo/work/nabors/genomes/10X_Genomics/VDJ/refdata-cellranger-vdj-GRCh38-alts-ensembl-2.0.0",
             CELLRANGER_CNV: "/igo/work/nabors/10X_Genomics_references/CNV/refdata-GRCh38-1.0.0",
-            CELLRANGER_COUNT: "/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A"
+            CELLRANGER_COUNT: "/igo/work/nabors/genomes/10X_Genomics/GEX/refdata-gex-GRCh38-2020-A",
+            HAPLOTYPE_MAP: "/home/igo/fingerprint_maps/map_files/hg38_chr.map"
         },
         "RNA": {
             REF_FLAT: '/igo/work/nabors/bed_files/GRCh38_100_Ensembl/Homo_sapiens.GRCh38.100.ref.flat',
@@ -442,7 +446,8 @@ recipe_options_mapping_UNORDERED = {
         BAITS: "/home/igo/resources/BED-Targets/MSK-ACCESS_v1/MSK-ACCESS-v1_0-probesAllwFP_GRCh38.interval_list",
         TARGETS: "/home/igo/resources/BED-Targets/MSK-ACCESS_v1/MSK-ACCESS-v1_0-probesAllwFP_GRCh38.interval_list",
         MSKQ: "no",
-        MD: "yes"
+        MD: "yes",
+        HAPLOTYPE_MAP: "/home/igo/fingerprint_maps/map_files/hg38_ACCESS.map"
     },
     "PanCancerV2": {
         BAITS: "/home/igo/resources/BED-Targets/PanCancerV2/PanCancerV2_BAITS.iList",

--- a/bin/run_param_config.py
+++ b/bin/run_param_config.py
@@ -37,6 +37,13 @@ MD="MD"
 +------------+          |                   |
 |   species  +----------+-------------------+
 +------------+
+
+species/refr -> recipe -> opts -> type          (Later options override previous options)
+
+    species/refr, species_genome_mapping: Default reference for organism
+    recipe, recipe_overrides: Specific reference required for recipe
+    opts, recipe_options_mapping: More specific options for a recipe (Not reference)
+    type, sample_type_mapping: WGS, RNA, or DNA
 """
 
 def get_ordered_dic(unordered_dic):

--- a/bin/test/test_generate_run_params.py
+++ b/bin/test/test_generate_run_params.py
@@ -274,6 +274,27 @@ class TestSetupStats(unittest.TestCase):
         self.assertEqual(wes_options[BAITS], "/home/igo/resources/ilist/IDT_Exome_v1_FP/b37/IDT_Exome_v1_FP_b37_baits.interval_list")
         self.assertEqual(wes_options[TARGETS], "/home/igo/resources/ilist/IDT_Exome_v1_FP/b37/IDT_Exome_v1_FP_b37_targets.interval_list")
 
+    def test_hMap_hg19(self):
+        hg19_recipes = [ "CH_v1" ]
+        for recipe in hg19_recipes:
+            params = get_recipe_species_params(recipe, "Human")
+            expected_params = "HAPLOTYPE_MAP=/home/igo/fingerprint_maps/map_files/hg19_ACCESS.map"
+            self.verify_params(params, expected_params, recipe, "Human")
+
+    def test_hMap_GRCh38(self):
+        grch38_recipes = [ "MSK-ACCESS_v1", "IMPACT505", "IDT_Exome_v2_FP_Viral_Probes" ]
+        for recipe in grch38_recipes:
+            params = get_recipe_species_params(recipe, "Human")
+            expected_params = "HAPLOTYPE_MAP=/home/igo/fingerprint_maps/map_files/hg38_chr.map"
+            self.verify_params(params, expected_params, recipe, "Human")
+
+    def test_hMap_GRCh37(self):
+        grch38_recipes = [ "ADCC1_v3" ]
+        for recipe in grch38_recipes:
+            params = get_recipe_species_params(recipe, "Human")
+            expected_params = "HAPLOTYPE_MAP=/igo/home/igo/fingerprint_maps/map_files/hg38_ACCESS.map"
+            self.verify_params(params, expected_params, recipe, "Human")
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/bin/test/test_generate_run_params.py
+++ b/bin/test/test_generate_run_params.py
@@ -301,14 +301,14 @@ class TestSetupStats(unittest.TestCase):
         self.assertEqual(wes_options[TARGETS], "/home/igo/resources/ilist/IDT_Exome_v1_FP/b37/IDT_Exome_v1_FP_b37_targets.interval_list")
 
     def test_hMap_hg19(self):
-        hg19_recipes = [ "CH_v1" ]
+        hg19_recipes = [ "CH_v1", "PCFDDR_v1", "PCFDDR_v2", "IWG_v2", "Twist_Exome", "IDT_Exome_v1", "ADCC1_v2", "RDM", "myTYPE_V1", "PanCancerV2", "MissionBio-Heme", "WholeExome_v4", "AmpliSeq", "HemeBrainPACT_v1" ]
         for recipe in hg19_recipes:
             params = get_recipe_species_params(recipe, "Human")
             expected_params = "HAPLOTYPE_MAP=/home/igo/fingerprint_maps/map_files/hg19_ACCESS.map"
             self.verify_params(params, expected_params, recipe, "Human")
 
     def test_hMap_GRCh38(self):
-        grch38_recipes = [ "IMPACT505", "IDT_Exome_v2_FP_Viral_Probes" ]
+        grch38_recipes = [ "IMPACT505", "IDT_Exome_v2_FP_Viral_Probes", "IMPACT341", "HemePACT_v4", "WholeExomeSequencing", "Agilent_v4_51MB_Human", "HumanWholeGenome", "ShallowWGS", "10X_Genomics_WGS", "AmpliconSeq" ]
         for recipe in grch38_recipes:
             params = get_recipe_species_params(recipe, "Human")
             expected_params = "HAPLOTYPE_MAP=/home/igo/fingerprint_maps/map_files/hg38_chr.map"

--- a/bin/test/test_generate_run_params.py
+++ b/bin/test/test_generate_run_params.py
@@ -292,7 +292,7 @@ class TestSetupStats(unittest.TestCase):
         grch38_recipes = [ "ADCC1_v3" ]
         for recipe in grch38_recipes:
             params = get_recipe_species_params(recipe, "Human")
-            expected_params = "HAPLOTYPE_MAP=/igo/home/igo/fingerprint_maps/map_files/hg38_ACCESS.map"
+            expected_params = "HAPLOTYPE_MAP=/home/igo/fingerprint_maps/map_files/GRCh37_ACCESS.map"
             self.verify_params(params, expected_params, recipe, "Human")
 
 if __name__ == '__main__':

--- a/bin/test/test_generate_run_params.py
+++ b/bin/test/test_generate_run_params.py
@@ -212,7 +212,7 @@ class TestSetupStats(unittest.TestCase):
 
     def test_MSK_ACCESS(self):
         params = get_recipe_species_params("MSK-ACCESS_v1", "Human")
-        expected_params = "BAITS=/home/igo/resources/BED-Targets/MSK-ACCESS_v1/MSK-ACCESS-v1_0-probesAllwFP_GRCh38.interval_list GTAG=GRCh38 GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa TARGETS=/home/igo/resources/BED-Targets/MSK-ACCESS_v1/MSK-ACCESS-v1_0-probesAllwFP_GRCh38.interval_list TYPE=DNA"
+        expected_params = "BAITS=/home/igo/resources/BED-Targets/MSK-ACCESS_v1/MSK-ACCESS-v1_0-probesAllwFP_GRCh38.interval_list GTAG=GRCh38 GENOME=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa MD=yes MSKQ=no REFERENCE=/igo/work/genomes/H.sapiens/GRCh38.p13/GRCh38.p13.dna.primary.assembly.fa TARGETS=/home/igo/resources/BED-Targets/MSK-ACCESS_v1/MSK-ACCESS-v1_0-probesAllwFP_GRCh38.interval_list TYPE=DNA HAPLOTYPE_MAP=/home/igo/fingerprint_maps/map_files/hg38_ACCESS.map"
         self.verify_params(params, expected_params, "MSK-ACCESS_v1", "Human")
 
     def test_CH_v1(self):
@@ -282,7 +282,7 @@ class TestSetupStats(unittest.TestCase):
             self.verify_params(params, expected_params, recipe, "Human")
 
     def test_hMap_GRCh38(self):
-        grch38_recipes = [ "MSK-ACCESS_v1", "IMPACT505", "IDT_Exome_v2_FP_Viral_Probes" ]
+        grch38_recipes = [ "IMPACT505", "IDT_Exome_v2_FP_Viral_Probes" ]
         for recipe in grch38_recipes:
             params = get_recipe_species_params(recipe, "Human")
             expected_params = "HAPLOTYPE_MAP=/home/igo/fingerprint_maps/map_files/hg38_chr.map"


### PR DESCRIPTION
Assigning `HAPLOTYPE_MAP` parameter when generating all params for a sample. Passing it to the `fingerprint_wkflw` and only running fingerprinting if a valid `.map` file has been assigned

**Created _GRCh37_ & _hg19_ `.map` files**
GRCh38 -> hg19 (Used `liftOver` to convert coordinates)
* `/home/igo/fingerprint_maps/map_files/hg19_ACCESS.map`

hg19 -> GRCh37 (Removed `chr` in front of every line of the hg19 `.map` file)
* `/home/igo/fingerprint_maps/map_files/GRCh37_ACCESS.map`


