### PR TITLE
Preventing PPG requests from proceeding

### DIFF
--- a/templates/generate_run_params.sh
+++ b/templates/generate_run_params.sh
@@ -130,8 +130,8 @@ else
       SAMPLE_DIRS=$(find ${PROJECT_DIR} -mindepth 1 -maxdepth 1 -type d)
 
       # For the DLP recipe, we output a single param line and skip as there are no Sample subdirectories of the demux directory
-      if [[ "${RECIPE}" = "DLP" ]]; then
-        echo "DLP recipes will be skipped. Not writting a ${RUN_PARAMS_FILE} file"
+      if [[ "${RECIPE}" = "DLP" || ! -z $(echo ${SAMPLESHEET} | grep ".*_PPG.csv$") ]]; then
+        echo "DLP/PPG recipes will be skipped. Not writting a ${RUN_PARAMS_FILE} file"
         # echo "RUNNAME=${RUNNAME} $SAMPLE_SHEET_PARAMS $PROJECT_PARAMS $TAGS" >> ${DLP_PARAM_FILE}
         continue
       fi


### PR DESCRIPTION
**DESCRIPTION:** PPG requests require a special manual workflow. We stop them from flowing through the regular stats workflow

**TESTING**
On `RUTH_0003_AHHL5KDSX2`
```
Received DEMUXED_DIR=/igo/work/streidd/NF_TESTING/FASTQ/RUTH_0003_AHHL5KDSX2_PPG SAMPLESHEET=/igo/work/streidd/NF_TESTING/DividedSampleSheets/SampleSheet_210709_RUTH_0003_AHHL5KDSX2_PPG.csv
Evaluated RUNNAME=RUTH_0003_AHHL5KDSX2 DEMUXED_DIR=/igo/work/streidd/NF_TESTING/FASTQ/RUTH_0003_AHHL5KDSX2_PPG SAMPLESHEET=/igo/work/streidd/NF_TESTING/DividedSampleSheets/SampleSheet_210709_RUTH_0003_AHHL5KDSX2_PPG.csv (RUN_PARAMS_FILE=sample_params.txt)
Launching RunName: RUTH_0003_AHHL5KDSX2, Run: RUTH_0003_AHHL5KDSX2_PPG, SampleSheet: /igo/work/streidd/NF_TESTING/DividedSampleSheets/SampleSheet_210709_RUTH_0003_AHHL5KDSX2_PPG.csv, RunType: PE, Dual Index: 71 PSR=[Project_08822_GO,Human,HumanWholeGenome,Project_08822_LT,Human,HumanWholeGenome;]
SAMPLE_SHEET_PARAMS: PROJECT=Project_08822_GO SPECIES=Human RECIPE=HumanWholeGenome RUN_TYPE=PE DUAL=71
DLP/PPG recipes will be skipped. Not writting a sample_params.txt file
SAMPLE_SHEET_PARAMS: PROJECT=Project_08822_LT SPECIES=Human RECIPE=HumanWholeGenome RUN_TYPE=PE DUAL=71
DLP/PPG recipes will be skipped. Not writting a sample_params.txt file
```