### PR TITLE
Ignoring failed demux

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -42,7 +42,7 @@ process {
   withLabel: BSUB_OPTIONS_DEMUX {
     cpus = 36
     memory = { 6.GB * task.attempt }
-    errorStrategy = 'retry'
+    errorStrategy = 'ignore'
     maxRetries = 3
     clusterOptions = "-o bsub_demux.out"
   }


### PR DESCRIPTION
**Description**: A failed demux would retry, but rarely will increasing memory (e.g. DLP cases) solve this. A failed demux will cause the whole pipeline to fail, which prevents successful split demuxes from continuing with stats. This change will ignore just the failed demux.