### PR TITLE
Retry when LSF can't find a host - will retry until hosts are available

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -31,7 +31,7 @@ process {
   withLabel: BSUB_OPTIONS_LARGE {
     cpus = 13
     memory = { 7.GB * task.attempt }
-    errorStrategy = { task.exitStatus in 137..140 ? 'retry' : : task.exitStatus == 255 ? 'retry' : 'terminate' }
+    errorStrategy = { task.exitStatus in 137..140 ? 'retry' : task.exitStatus == 255 ? 'retry' : 'terminate' }
     maxRetries = 1
     clusterOptions = "-o bsub.out"
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,6 +11,7 @@ process {
   withName: align_to_reference_task {
     cpus = 1
     memory = 1.GB
+    errorStrategy = { task.exitStatus == 255 ? 'retry' : 'terminate' }
   }
   withLabel: LOCAL {
     executor="local"
@@ -18,17 +19,19 @@ process {
   withLabel: simple_lsf_task {
     cpus = 1
     memory = 1.GB
+    errorStrategy = { task.exitStatus == 255 ? 'retry' : 'terminate' }
     clusterOptions = "-o simple_lsf_task.out"
   }
   withLabel: BSUB_OPTIONS_BWA_MEM {
     cpus = 40
     memory = 5.GB
+    errorStrategy = { task.exitStatus == 255 ? 'retry' : 'terminate' }
     clusterOptions = "-o bsub_bwa_mem.out"
   }
   withLabel: BSUB_OPTIONS_LARGE {
     cpus = 13
     memory = { 7.GB * task.attempt }
-    errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+    errorStrategy = { task.exitStatus in 137..140 ? 'retry' : : task.exitStatus == 255 ? 'retry' : 'terminate' }
     maxRetries = 1
     clusterOptions = "-o bsub.out"
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,7 +35,7 @@ process {
   withLabel: BSUB_OPTIONS_SMALL {
     cpus = 8
     memory = { 6.GB * task.attempt }
-    errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+    errorStrategy = { task.exitStatus in 137..140 ? 'retry' : task.exitStatus == 255 ? 'retry' : 'terminate' }
     maxRetries = 1
     clusterOptions = "-o bsub.out"
   }


### PR DESCRIPTION
**Description**: Nextflow exits when there aren't enough hosts available, this will retry until enough hosts become available

**ERROR**
```
Command exit status:
  255

Command output:
  Failed in an LSF library call: Not enough host(s) currently eligible. Job not submitted.
```