### PR TITLE
Writing merge commands to file

### DIFF
--- a/bin/create_merge_commands.py
+++ b/bin/create_merge_commands.py
@@ -255,7 +255,7 @@ def create_merge_commands(merge_info, samtools):
     bash_commands = ""
     for target_file, file_list in merge_info.items():
         to_write_dir = "$(dirname %s)" % target_file
-        mkdir_cmd="mkdir -p %" % to_write_dir  # Create parent directory for merged bam prior to writing it
+        mkdir_cmd="mkdir -p %s" % to_write_dir  # Create parent directory for merged bam prior to writing it
         if len(file_list) == 1:
             # Don't merge a single file. Create directory for project and copy it to the BAM directory
             merge_cmd = "cp %s %s" % (file_list[0], target_file)

--- a/bin/test/test_create_merge_commands.py
+++ b/bin/test/test_create_merge_commands.py
@@ -45,12 +45,12 @@ class CreateMergeCommand(unittest.TestCase):
         content = get_merge_commands(files, bam_dir, config.LIMS_HOST_PROD, "/usr/bin/samtools")
 
         expected_commands = [
-            [ "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_1___C-7JJ452___NA.bam) &&",
-              "cp JAX_0375_AHFGVNBBXY___P09455_S___S19-48533_IGO_09455_S_1___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_1___C-7JJ452___NA.bam" ],
-            [ "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_5___C-J0UH5P___NA.bam) &&",
-              "cp JAX_0375_AHFGVNBBXY___P09455_S___C-19-208557_IGO_09455_S_5___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_5___C-J0UH5P___NA.bam" ],
-            [ "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_2___C-2M22RC___NA.bam) &&",
-              "cp JAX_0375_AHFGVNBBXY___P09455_S___S19-53420_IGO_09455_S_2___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_2___C-2M22RC___NA.bam" ]
+            [ "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_1___NO_CMO_PID___NA.bam) &&",
+              "cp JAX_0375_AHFGVNBBXY___P09455_S___S19-48533_IGO_09455_S_1___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_1___NO_CMO_PID___NA.bam" ],
+            [ "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_5___NO_CMO_PID___NA.bam) &&",
+              "cp JAX_0375_AHFGVNBBXY___P09455_S___C-19-208557_IGO_09455_S_5___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_5___NO_CMO_PID___NA.bam" ],
+            [ "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_2___NO_CMO_PID___NA.bam) &&",
+              "cp JAX_0375_AHFGVNBBXY___P09455_S___S19-53420_IGO_09455_S_2___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_2___NO_CMO_PID___NA.bam" ]
         ]
 
         verify_commands(self, content, expected_commands)
@@ -103,7 +103,10 @@ class CreateMergeCommand(unittest.TestCase):
 
         f = open(output, "r")
         command = f.read().strip()
-        bam_name = command.split(' ')[-1]
+
+        # Ahhh...
+        bams = [ f for f in command.split() if f[-4:] == ".bam" ]
+        bam_name = bams[1]
 
         self.assertEqual(bam_name, TANGO_BAM)
 
@@ -128,7 +131,10 @@ class CreateMergeCommand(unittest.TestCase):
 
         f = open(output, "r")
         command = f.read().strip()
-        bam_name = command.split(' ')[-1]
+
+        # Ahhh...
+        bams = [ f for f in command.split() if f[-4:] == ".bam" ]
+        bam_name = bams[1]
 
         print(command)
 
@@ -151,13 +157,13 @@ class CreateMergeCommand(unittest.TestCase):
             ...
         ]
         """
-        original_bam = '/ifs/res/GCL/hiseq/Stats/JAX_0435_AHH3F7BBXY/JAX_0435_AHH3F7BBXY___P10862___HSS12_IGO_10862_3___GRCh37.bam'
+        original_bam = '/ifs/res/GCL/hiseq/Stats/JAX_0435_AHH3F7BBXY/JAX_0435_AHH3F7BBXY___P10862___NO_CMO_PID_IGO_10862_3___GRCh37.bam'
         files = [ original_bam ]
         project = '10862'
         content = get_merge_commands(files, project, config.LIMS_HOST_PROD, "/usr/bin/samtools")
         expected_content = [
-            [ "mkdir -p $(dirname 10862/P10862/10862_3___HSS12___Normal.bam) &&",
-              "cp /ifs/res/GCL/hiseq/Stats/JAX_0435_AHH3F7BBXY/JAX_0435_AHH3F7BBXY___P10862___HSS12_IGO_10862_3___GRCh37.bam 10862/P10862/10862_3___HSS12___Normal.bam" ]
+            [ "mkdir -p $(dirname 10862/P10862/10862_3___NO_CMO_PID___NA.bam) &&",
+              "cp /ifs/res/GCL/hiseq/Stats/JAX_0435_AHH3F7BBXY/JAX_0435_AHH3F7BBXY___P10862___NO_CMO_PID_IGO_10862_3___GRCh37.bam 10862/P10862/10862_3___NO_CMO_PID___NA.bam" ]
         ]
 
         verify_commands(self, content, expected_content)

--- a/bin/test/test_create_merge_commands.py
+++ b/bin/test/test_create_merge_commands.py
@@ -6,8 +6,8 @@ sys.path.append('..')       # If running from bin
 from create_merge_commands import get_merge_commands, main
 import config
 
-PROD_BAM = './P06302_AG/06302_AG_125___C-4RKTFD___Tumor.bam'        # TODO - now there isn't an example of same
-TANGO_BAM = './P06302_AG/06302_AG_125___C-4RKTFD___Tumor.bam'
+PROD_BAM = './P06302_AG/06302_AG_125___NO_CMO_PID___NA.bam'        # TODO - now there isn't an example of same
+TANGO_BAM = './P06302_AG/06302_AG_125___NO_CMO_PID___NA.bam'
 
 def verify_commands(self, cmd_file, expected_commands):
     actual_commands = cmd_file.strip().split("\n")
@@ -45,12 +45,12 @@ class CreateMergeCommand(unittest.TestCase):
         content = get_merge_commands(files, bam_dir, config.LIMS_HOST_PROD, "/usr/bin/samtools")
 
         expected_commands = [
-            [ "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_1___C-7JJ452___Tumor.bam) &&",
-              "cp JAX_0375_AHFGVNBBXY___P09455_S___S19-48533_IGO_09455_S_1___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_1___C-7JJ452___Tumor.bam" ],
-            [ "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_5___C-J0UH5P___Tumor.bam) &&",
-              "cp JAX_0375_AHFGVNBBXY___P09455_S___C-19-208557_IGO_09455_S_5___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_5___C-J0UH5P___Tumor.bam" ],
-            [ "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_2___C-2M22RC___Tumor.bam) &&",
-              "cp JAX_0375_AHFGVNBBXY___P09455_S___S19-53420_IGO_09455_S_2___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_2___C-2M22RC___Tumor.bam" ]
+            [ "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_1___C-7JJ452___NA.bam) &&",
+              "cp JAX_0375_AHFGVNBBXY___P09455_S___S19-48533_IGO_09455_S_1___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_1___C-7JJ452___NA.bam" ],
+            [ "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_5___C-J0UH5P___NA.bam) &&",
+              "cp JAX_0375_AHFGVNBBXY___P09455_S___C-19-208557_IGO_09455_S_5___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_5___C-J0UH5P___NA.bam" ],
+            [ "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_2___C-2M22RC___NA.bam) &&",
+              "cp JAX_0375_AHFGVNBBXY___P09455_S___S19-53420_IGO_09455_S_2___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_2___C-2M22RC___NA.bam" ]
         ]
 
         verify_commands(self, content, expected_commands)

--- a/bin/test/test_create_merge_commands.py
+++ b/bin/test/test_create_merge_commands.py
@@ -6,8 +6,21 @@ sys.path.append('..')       # If running from bin
 from create_merge_commands import get_merge_commands, main
 import config
 
-PROD_BAM = './P06302_AG/06302_AG_125___NO_CMO_PID___NA.bam'        # TODO - now there isn't an example of same
-TANGO_BAM = './P06302_AG/06302_AG_125___NO_CMO_PID___NA.bam'
+PROD_BAM = './P06302_AG/06302_AG_125___C-4RKTFD___Tumor.bam'        # TODO - now there isn't an example of same
+TANGO_BAM = './P06302_AG/06302_AG_125___C-4RKTFD___Tumor.bam'
+
+def verify_commands(self, cmd_file, expected_commands):
+    actual_commands = cmd_file.strip().split("\n")
+
+    # Check expected number of commands were written
+    self.assertEqual(len(expected_commands), len(actual_commands), "Number of commands don't match\n%s" % cmd_file)
+    num_cmds = len(expected_commands)
+
+    for i in range(num_cmds):
+        cmd = actual_commands[i]
+        expected_parts = expected_commands[i]
+        for pt in expected_parts:
+            self.assertTrue(pt in cmd, "PART not in CMD (PART='%s', CMD='%s')" % (pt, cmd))
 
 class CreateMergeCommand(unittest.TestCase):
     """
@@ -19,6 +32,7 @@ class CreateMergeCommand(unittest.TestCase):
     $ python3 create_merge_commands_test.py CreateMergeCommand.test_command_line_args_tango
     $ python3 create_merge_commands_test.py CreateMergeCommand.test_missing_cmoPatientId_sampleName_replacement
     """
+
     def test_merge_commands(self):
         """
         Test that it can sum a list of integers
@@ -29,10 +43,17 @@ class CreateMergeCommand(unittest.TestCase):
             'JAX_0375_AHFGVNBBXY___P09455_S___S19-53420_IGO_09455_S_2___GRCh37.bam']
         bam_dir = '/igo/staging/BAM'
         content = get_merge_commands(files, bam_dir, config.LIMS_HOST_PROD, "/usr/bin/samtools")
-        expected_content = "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_1___NO_CMO_PID___NA.bam) && cp JAX_0375_AHFGVNBBXY___P09455_S___S19-48533_IGO_09455_S_1___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_1___NO_CMO_PID___NA.bam\n" + \
-                           "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_5___NO_CMO_PID___NA.bam) && cp JAX_0375_AHFGVNBBXY___P09455_S___C-19-208557_IGO_09455_S_5___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_5___NO_CMO_PID___NA.bam\n" + \
-                           "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_2___NO_CMO_PID___NA.bam) && cp JAX_0375_AHFGVNBBXY___P09455_S___S19-53420_IGO_09455_S_2___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_2___NO_CMO_PID___NA.bam\n"
-        self.assertEqual(content, expected_content)
+
+        expected_commands = [
+            [ "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_1___C-7JJ452___Tumor.bam) &&",
+              "cp JAX_0375_AHFGVNBBXY___P09455_S___S19-48533_IGO_09455_S_1___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_1___C-7JJ452___Tumor.bam" ],
+            [ "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_5___C-J0UH5P___Tumor.bam) &&",
+              "cp JAX_0375_AHFGVNBBXY___P09455_S___C-19-208557_IGO_09455_S_5___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_5___C-J0UH5P___Tumor.bam" ],
+            [ "mkdir -p $(dirname /igo/staging/BAM/P09455_S/09455_S_2___C-2M22RC___Tumor.bam) &&",
+              "cp JAX_0375_AHFGVNBBXY___P09455_S___S19-53420_IGO_09455_S_2___GRCh37.bam /igo/staging/BAM/P09455_S/09455_S_2___C-2M22RC___Tumor.bam" ]
+        ]
+
+        verify_commands(self, content, expected_commands)
 
     def test_corrected_ids(self):
         project = 'PROJECT'
@@ -109,6 +130,8 @@ class CreateMergeCommand(unittest.TestCase):
         command = f.read().strip()
         bam_name = command.split(' ')[-1]
 
+        print(command)
+
         self.assertEqual(bam_name, PROD_BAM)
 
     def test_missing_cmoPatientId_sampleName_replacement(self):
@@ -132,8 +155,12 @@ class CreateMergeCommand(unittest.TestCase):
         files = [ original_bam ]
         project = '10862'
         content = get_merge_commands(files, project, config.LIMS_HOST_PROD, "/usr/bin/samtools")
-        expected_content = "mkdir -p $(dirname 10862/P10862/10862_3___NO_CMO_PID___NA.bam) && cp %s 10862/P10862/10862_3___NO_CMO_PID___NA.bam\n" % original_bam
-        self.assertEqual(content, expected_content)
+        expected_content = [
+            [ "mkdir -p $(dirname 10862/P10862/10862_3___HSS12___Normal.bam) &&",
+              "cp /ifs/res/GCL/hiseq/Stats/JAX_0435_AHH3F7BBXY/JAX_0435_AHH3F7BBXY___P10862___HSS12_IGO_10862_3___GRCh37.bam 10862/P10862/10862_3___HSS12___Normal.bam" ]
+        ]
+
+        verify_commands(self, content, expected_content)
 
 if __name__ == '__main__':
     unittest.main()

--- a/modules/create_sample_bams.nf
+++ b/modules/create_sample_bams.nf
@@ -20,13 +20,8 @@ process task {
   output:
     stdout()
 
-  script:
-    '''
-    # Evaluate the merge command (e.g. "samtools merge ${TARGET_BAM} ${SRC_BAM_1} ${SRC_BAM_2}...")
-    echo ${MERGE_CMD} >> ${CMD_FILE}
-    echo ${MERGE_CMD}
-    eval ${MERGE_CMD}
-    '''
+  shell:
+    template 'run_merge_cmd.sh'
 }
 
 workflow create_sample_bams_wkflw {

--- a/templates/run_merge_cmd.sh
+++ b/templates/run_merge_cmd.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Evaluate the merge command (e.g. "samtools merge ${TARGET_BAM} ${SRC_BAM_1} ${SRC_BAM_2}...")
+echo ${MERGE_CMD} >> ${CMD_FILE}
+echo ${MERGE_CMD}
+eval ${MERGE_CMD}


### PR DESCRIPTION
**Description**: Fixing issue where only 1-2 sample BAMs are written

**Changes**:
* Move command logic to `run_merge_cmd.sh`
* Writes merge commands to directory in `SAMPLE_BAM_DIR`

**Testing**:
Example RUN (`RUTH_0018`) that generates `merge_commands.out` and writes all the BAMs, both `cp`'d and `samtools merge`'d 
```
$ cat /igo/work/streidd/temp/OUTPUTS/stats/BAM/P11871_D/merge_commands.out
cp /igo/work/streidd/temp/OUTPUTS/stats/MICHELLE_0434_AH2TJNDMXY/MICHELLE_0434_AH2TJNDMXY___P11871_D___2-3_IGO_11871_D_6___grcm38.bam /igo/work/streidd/temp/OUTPUTS/stats/BAM/P11871_D/11871_D_6___NO_CMO_PID___NA.bam
cp /igo/work/streidd/temp/OUTPUTS/stats/MICHELLE_0434_AH2TJNDMXY/MICHELLE_0434_AH2TJNDMXY___P11871_D___2-2_IGO_11871_D_5___grcm38.bam /igo/work/streidd/temp/OUTPUTS/stats/BAM/P11871_D/11871_D_5___NO_CMO_PID___NA.bam
cp /igo/work/streidd/temp/OUTPUTS/stats/MICHELLE_0434_AH2TJNDMXY/MICHELLE_0434_AH2TJNDMXY___P11871_D___1-2_IGO_11871_D_2___grcm38.bam /igo/work/streidd/temp/OUTPUTS/stats/BAM/P11871_D/11871_D_2___NO_CMO_PID___NA.bam
cp /igo/work/streidd/temp/OUTPUTS/stats/MICHELLE_0434_AH2TJNDMXY/MICHELLE_0434_AH2TJNDMXY___P11871_D___1-3_IGO_11871_D_3___grcm38.bam /igo/work/streidd/temp/OUTPUTS/stats/BAM/P11871_D/11871_D_3___NO_CMO_PID___NA.bam
cp /igo/work/streidd/temp/OUTPUTS/stats/MICHELLE_0434_AH2TJNDMXY/MICHELLE_0434_AH2TJNDMXY___P11871_D___1-1_IGO_11871_D_1___grcm38.bam /igo/work/streidd/temp/OUTPUTS/stats/BAM/P11871_D/11871_D_1___NO_CMO_PID___NA.bam
/igo/work/bin/tapestri/pipeline/bin/samtools merge /igo/work/streidd/temp/OUTPUTS/stats/BAM/P11871_D/11871_D_4___NO_CMO_PID___NA.bam /igo/work/streidd/temp/OUTPUTS/stats/MICHELLE_0434_AH2TJNDMXY/MICHELLE_0434_AH2TJNDMXY___P11871_D___2-1_IGO_11871_D_4___grcm38.bam /igo/work/streidd/temp/OUTPUTS/stats/RUTH_0018_BHGTFJDRXY/RUTH_0018_BHGTFJDRXY___P11871_D___2-1_IGO_11871_D_4___grcm38.bam
```