### PR TITLE
Appending RECIPE to RUN_TAG

### DIFF
--- a/templates/generate_run_params.sh
+++ b/templates/generate_run_params.sh
@@ -160,7 +160,7 @@ else
           continue
         fi
 
-        RUN_TAG="${RUNNAME}___${PROJECT_TAG}___${SAMPLE_TAG}___${GTAG}" # RUN_TAG will determine the name of output stats
+        RUN_TAG="${RUNNAME}___${PROJECT_TAG}___${SAMPLE_TAG}___${GTAG}___${RECIPE}" # RUN_TAG will determine the name of output stats
         FINAL_BAM=${STATS_DIR}/${RUNNAME}/${RUN_TAG}.bam                # Location of final BAM for sample
 
         # We add the final BAM & RUN_TAG so we can check that the BAM was written and stats of name ${RUN_TAG} exist


### PR DESCRIPTION
**Description**: This appends the `RECIPE` to the `RUN_TAG` that names all sample SAM, BAM, & stats files. This is to distinguish samples that otherwise have the same sample_id (`SAMPLE_TAG`) and are part of the same project (`PROJECT_TAG`) & run (`RUNNAME`).
* This is an issue w/ MissionBio Protein & DNA samples that originate from the same sample w/ the same SampleID. It is also anticipated that future workflows will generate multiple child samples from the same sample, which will all have the same Sample ID
